### PR TITLE
Update for SMAPI 3.0 changes

### DIFF
--- a/ButcherMod/AnimalHusbandryMod.csproj
+++ b/ButcherMod/AnimalHusbandryMod.csproj
@@ -123,7 +123,7 @@
     <Compile Include="tools\FeedingBasket.cs" />
     <Compile Include="tools\InseminationSyringe.cs" />
     <Compile Include="tools\MeatCleaver.cs" />
-    <Compile Include="AnimalHusbandryModEntery.cs" />
+    <Compile Include="AnimalHusbandryModEntry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="recipes\MeatFridayChannel.cs" />
     <Compile Include="tools\ToolsLoader.cs" />

--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using AnimalHusbandryMod.animals;
+using AnimalHusbandryMod.farmer;
+using AnimalHusbandryMod.meats;
+using AnimalHusbandryMod.tools;
+using Harmony;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
-using Harmony;
-using AnimalHusbandryMod.farmer;
-using AnimalHusbandryMod.tools;
-using AnimalHusbandryMod.meats;
 using DataLoader = AnimalHusbandryMod.common.DataLoader;
+using SObject = StardewValley.Object;
 
 namespace AnimalHusbandryMod
 {
@@ -74,9 +75,10 @@ namespace AnimalHusbandryMod
 
                 try
                 {
-                    var farmAnimalPet = typeof(FarmAnimal).GetMethod("pet");
-                    var animalQueryMenuExtendedPet = typeof(AnimalQueryMenuExtended).GetMethod("Pet");
-                    harmony.Patch(farmAnimalPet, new HarmonyMethod(animalQueryMenuExtendedPet), null);
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(FarmAnimal), nameof(FarmAnimal.pet)),
+                        prefix: new HarmonyMethod(typeof(AnimalQueryMenuExtended), nameof(AnimalQueryMenuExtended.Pet))
+                    );
                 }
                 catch (Exception)
                 {
@@ -92,30 +94,33 @@ namespace AnimalHusbandryMod
 
                 if (!DataLoader.ModConfig.DisableRancherMeatPriceAjust)
                 {
-                    var sellToStorePrice = typeof(StardewValley.Object).GetMethod("sellToStorePrice");
-                    var sellToStorePricePrefix = typeof(MeatOverrides).GetMethod("sellToStorePrice");
-                    harmony.Patch(sellToStorePrice, new HarmonyMethod(sellToStorePricePrefix), null);
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(SObject), nameof(SObject.sellToStorePrice)),
+                        prefix: new HarmonyMethod(typeof(MeatOverrides), nameof(MeatOverrides.sellToStorePrice))
+                    );
                 }
 
                 if (!DataLoader.ModConfig.DisableMeat)
                 {
-                    var objectIsPotentialBasicShippedCategory = typeof(StardewValley.Object).GetMethod("isPotentialBasicShippedCategory");
-                    var meatOverridesIsPotentialBasicShippedCategory = typeof(MeatOverrides).GetMethod("isPotentialBasicShippedCategory");
-                    harmony.Patch(objectIsPotentialBasicShippedCategory, new HarmonyMethod(meatOverridesIsPotentialBasicShippedCategory), null);
-
-                    var objectCountsForShippedCollection = typeof(StardewValley.Object).GetMethod("countsForShippedCollection");
-                    var meatOverridesCountsForShippedCollection = typeof(MeatOverrides).GetMethod("countsForShippedCollection");
-                    harmony.Patch(objectCountsForShippedCollection, new HarmonyMethod(meatOverridesCountsForShippedCollection), null);
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(SObject), nameof(SObject.isPotentialBasicShippedCategory)),
+                        prefix: new HarmonyMethod(typeof(MeatOverrides), nameof(MeatOverrides.isPotentialBasicShippedCategory))
+                    );
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(SObject), nameof(SObject.countsForShippedCollection)),
+                        prefix: new HarmonyMethod(typeof(MeatOverrides), nameof(MeatOverrides.countsForShippedCollection))
+                    );
                 }
 
-                //var addSpecificTemporarySprite = typeof(Event).GetMethod("addSpecificTemporarySprite");
-                //var addSpecificTemporarySprite = this.Helper.Reflection.GetMethod(new Event(), "addSpecificTemporarySprite").MethodInfo;
-                //var addSpecificTemporarySpritePostfix = typeof(EventsOverrides).GetMethod("addSpecificTemporarySprite");
-                //harmony.Patch(addSpecificTemporarySprite, null, new HarmonyMethod(addSpecificTemporarySpritePostfix));
+                //harmony.Patch(
+                //    original: AccessTools.Method(typeof(Event), "addSpecificTemporarySprite"),
+                //    transpiler: new HarmonyMethod(typeof(EventsOverrides), nameof(EventsOverrides.addSpecificTemporarySprite))
+                //);
 
-                //var petCheckAction = typeof(Pet).GetMethod("checkAction");
-                //var petCheckActionPrefix = typeof(PetOverrides).GetMethod("checkAction");
-                //harmony.Patch(petCheckAction, new HarmonyMethod(petCheckActionPrefix), null);
+                //harmony.Patch(
+                //    original: AccessTools.Method(typeof(Pet), nameof(Pet.checkAction)),
+                //    prefix: new HarmonyMethod(typeof(PetOverrides), nameof(PetOverrides.checkAction))
+                //);
             }
         }
 

--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -12,7 +12,7 @@ using DataLoader = AnimalHusbandryMod.common.DataLoader;
 
 namespace AnimalHusbandryMod
 {
-    public class AnimalHusbandryModEntery : Mod
+    public class AnimalHusbandryModEntry : Mod
     {
 
         internal static IModHelper ModHelper;
@@ -82,7 +82,7 @@ namespace AnimalHusbandryMod
                 }
                 catch (Exception)
                 {
-                    Monitor.Log("Erro patching the FarmAnimal 'pet' Method. Applying old method of opening the extended animal query menu.", LogLevel.Warn);
+                    Monitor.Log("Error patching the FarmAnimal 'pet' Method. Applying old method of opening the extended animal query menu.", LogLevel.Warn);
                     helper.Events.Display.MenuChanged += (s, e) =>
                     {
                         if (e.NewMenu is AnimalQueryMenu && !(e.NewMenu is AnimalQueryMenuExtended))

--- a/ButcherMod/animals/PregnancyController.cs
+++ b/ButcherMod/animals/PregnancyController.cs
@@ -15,7 +15,7 @@ namespace AnimalHusbandryMod.animals
 {
     public class PregnancyController
     {
-        private static IModEvents events => AnimalHusbandryModEntery.ModHelper.Events;
+        private static IModEvents events => AnimalHusbandryModEntry.ModHelper.Events;
         static Queue<FarmAnimal> parentAnimals = new Queue<FarmAnimal>();
         static FarmAnimal parentAnimal = null;
 
@@ -109,7 +109,7 @@ namespace AnimalHusbandryMod.animals
             }
             else
             {
-                AnimalHusbandryModEntery.monitor.Log($"The animal id '{id}' was not found in the game and its pregnancy data is being discarted.", LogLevel.Warn);
+                AnimalHusbandryModEntry.monitor.Log($"The animal id '{id}' was not found in the game and its pregnancy data is being discarted.", LogLevel.Warn);
                 PregnancyController.RemovePregnancyItem(id);
                 return null;
             }

--- a/ButcherMod/common/DataLoader.cs
+++ b/ButcherMod/common/DataLoader.cs
@@ -43,33 +43,25 @@ namespace AnimalHusbandryMod.common
             LooseSpritesName = Helper.Content.GetActualAssetKey("common/LooseSprites.png", ContentSource.ModFolder);
             LooseSprites = Helper.Content.Load<Texture2D>("common/LooseSprites.png");
 
-            var editors = Helper.Content.AssetEditors;
-
-            //editors.Add(new EventsLoader());
-
-            if (!ModConfig.DisableMeat)
-            {               
-                editors.Add(this);
-            }
-
+            // load tools
             ToolsSprites = Helper.Content.Load<Texture2D>("tools/Tools.png");
             ToolsLoader = new ToolsLoader(ToolsSprites, Helper.Content.Load<Texture2D>("tools/MenuTiles.png"), Helper.Content.Load<Texture2D>("common/CustomLetterBG.png"));   
-            editors.Add(ToolsLoader);
             ToolsLoader.LoadMail();
 
+            // load recipes
             if (!ModConfig.DisableMeat)
             {
                 RecipeLoader = new RecipesLoader();
-                editors.Add(RecipeLoader);
                 RecipeLoader.LoadMails();
             }
 
+            // load animal data
             AnimalBuildingData = DataLoader.Helper.Data.ReadJsonFile<AnimalBuildingData>("data\\animalBuilding.json") ?? new AnimalBuildingData();
             DataLoader.Helper.Data.WriteJsonFile("data\\animalBuilding.json", AnimalBuildingData);
-
             AnimalData = DataLoader.Helper.Data.ReadJsonFile<AnimalData>("data\\animals.json") ?? new AnimalData();
             DataLoader.Helper.Data.WriteJsonFile("data\\animals.json", AnimalData);
 
+            // look cooking data
             CookingData = Helper.Data.ReadJsonFile<CookingData>("data\\cooking.json") ?? new CookingData();
             if (CookingData.Meatloaf.Recipe == null)
             {
@@ -77,7 +69,18 @@ namespace AnimalHusbandryMod.common
             }
             Helper.Data.WriteJsonFile("data\\cooking.json", CookingData);
 
+            // load TV channel
             LivingWithTheAnimalsChannel = new LivingWithTheAnimalsChannel();
+
+            // add editors (must happen *after* data is initialised above, since SMAPI may reload affected assets immediately)
+            var editors = Helper.Content.AssetEditors;
+            //editors.Add(new EventsLoader());
+            editors.Add(ToolsLoader);
+            if (!ModConfig.DisableMeat)
+            {
+                editors.Add(this);
+                editors.Add(RecipeLoader);
+            }
         }
 
         public bool CanEdit<T>(IAssetInfo asset)

--- a/ButcherMod/recipes/RecipesLoader.cs
+++ b/ButcherMod/recipes/RecipesLoader.cs
@@ -95,13 +95,13 @@ namespace AnimalHusbandryMod.recipes
                     if (!Game1.player.cookingRecipes.ContainsKey(cooking.GetDescription()))
                     {
                         Game1.player.cookingRecipes.Add(cooking.GetDescription(), 0);
-                        AnimalHusbandryModEntery.monitor.Log($"Added {cooking.GetDescription()} recipe to the player.", LogLevel.Info);
+                        AnimalHusbandryModEntry.monitor.Log($"Added {cooking.GetDescription()} recipe to the player.", LogLevel.Info);
                     }
                 }
             }
             else
             {
-                AnimalHusbandryModEntery.monitor.Log("No player loaded to add the recipes.", LogLevel.Info);
+                AnimalHusbandryModEntry.monitor.Log("No player loaded to add the recipes.", LogLevel.Info);
             }
         }
     }

--- a/ButcherMod/tools/FeedingBasket.cs
+++ b/ButcherMod/tools/FeedingBasket.cs
@@ -299,7 +299,7 @@ namespace AnimalHusbandryMod.tools
                 if (this._animal != null)
                 {
                     Game1.delayedActions.Add(new DelayedAction(300, new DelayedAction.delayedBehavior(() => {
-                        AnimalHusbandryModEntery.ModHelper.Reflection.GetField<NetBool>(this._animal, "isEating").GetValue().Value = true;
+                        AnimalHusbandryModEntry.ModHelper.Reflection.GetField<NetBool>(this._animal, "isEating").GetValue().Value = true;
                         this._animal.Sprite.loop = false;
                     })));
                 }

--- a/ButcherMod/tools/ToolsLoader.cs
+++ b/ButcherMod/tools/ToolsLoader.cs
@@ -155,12 +155,12 @@ namespace AnimalHusbandryMod.tools
                 if (item.Name.Contains("ButcherMod.MeatCleaver"))
                 {
                     items[i] = new MeatCleaver();
-                    AnimalHusbandryModEntery.monitor.Log($"An older version of the MeatCleaver found. Replacing it with the new one.", LogLevel.Debug);
+                    AnimalHusbandryModEntry.monitor.Log($"An older version of the MeatCleaver found. Replacing it with the new one.", LogLevel.Debug);
                 }
                 else if (item.Name.Contains("ButcherMod.tools.InseminationSyringe"))
                 {
                     items[i] = new InseminationSyringe();
-                    AnimalHusbandryModEntery.monitor.Log($"An older version of the InseminationSyringe found. Replacing it with the new one.", LogLevel.Debug);
+                    AnimalHusbandryModEntry.monitor.Log($"An older version of the InseminationSyringe found. Replacing it with the new one.", LogLevel.Debug);
                 }
             }
         }

--- a/ButcherMod/tools/ToolsLoader.cs
+++ b/ButcherMod/tools/ToolsLoader.cs
@@ -103,7 +103,7 @@ namespace AnimalHusbandryMod.tools
             }
         }
 
-        internal void ReplaceOldTools(object sender, EventArgs e)
+        internal void ReplaceOldTools()
         {
             IList<Item> inventory = Game1.player.Items;
             for (int i = 0; i < inventory.Count; i++)

--- a/CropTransplantMod/CropTransplantModEntry.cs
+++ b/CropTransplantMod/CropTransplantModEntry.cs
@@ -6,16 +6,37 @@ using StardewValley.TerrainFeatures;
 
 namespace CropTransplantMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class CropTransplantModEntry : Mod
     {
         public static IMonitor ModMonitor;
         public static IModEvents Events;
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             ModMonitor = Monitor;
             Events = helper.Events;
-            new DataLoader(helper);
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.Saving += OnSaving;
+        }
+
+        
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            new DataLoader(Helper);
 
             var harmony = HarmonyInstance.Create("Digus.CustomCrystalariumMod");
 
@@ -49,15 +70,18 @@ namespace CropTransplantMod
                 var transplantOverridesPreTreeDraw = typeof(TransplantOverrides).GetMethod("PreTreeDraw");
                 harmony.Patch(treeDraw, new HarmonyMethod(transplantOverridesPreTreeDraw), null);
             }
+        }
 
-            helper.Events.GameLoop.Saving += (sender, e) =>
+        /// <summary>Raised before the game begins writes data to the save file (except the initial save creation).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnSaving(object sender, SavingEventArgs e)
+        {
+            if (Game1.player.ActiveObject is HeldIndoorPot)
             {
-                if (Game1.player.ActiveObject is HeldIndoorPot)
-                {
-                    Game1.player.ActiveObject = TransplantOverrides.RegularPotObject;
-                    TransplantOverrides.CurrentHeldIndoorPot = null;
-                }
-            };
+                Game1.player.ActiveObject = TransplantOverrides.RegularPotObject;
+                TransplantOverrides.CurrentHeldIndoorPot = null;
+            }
         }
     }
 }

--- a/CropTransplantMod/CropTransplantModEntry.cs
+++ b/CropTransplantMod/CropTransplantModEntry.cs
@@ -40,35 +40,42 @@ namespace CropTransplantMod
 
             var harmony = HarmonyInstance.Create("Digus.CustomCrystalariumMod");
 
-            var utilityTryToPlaceItem = typeof(Utility).GetMethod("tryToPlaceItem");
-            var objectOverridesTryToPlaceItem = typeof(TransplantOverrides).GetMethod("TryToPlaceItem");
-            harmony.Patch(utilityTryToPlaceItem, new HarmonyMethod(objectOverridesTryToPlaceItem), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Utility), nameof(Utility.tryToPlaceItem)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.TryToPlaceItem))
+            );
 
-            var utilityCanGrabSomethingFromHere = typeof(Utility).GetMethod("canGrabSomethingFromHere");
-            var objectOverridesCanGrabSomethingFromHere = typeof(TransplantOverrides).GetMethod("CanGrabSomethingFromHere");
-            harmony.Patch(utilityCanGrabSomethingFromHere, new HarmonyMethod(objectOverridesCanGrabSomethingFromHere), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Utility), nameof(Utility.canGrabSomethingFromHere)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.CanGrabSomethingFromHere))
+            );
 
-            var utilityPlayerCanPlaceItemHere = typeof(Utility).GetMethod("playerCanPlaceItemHere");
-            var objectOverridesPlayerCanPlaceItemHere = typeof(TransplantOverrides).GetMethod("PlayerCanPlaceItemHere");
-            harmony.Patch(utilityPlayerCanPlaceItemHere, new HarmonyMethod(objectOverridesPlayerCanPlaceItemHere), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Utility), nameof(Utility.playerCanPlaceItemHere)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.PlayerCanPlaceItemHere))
+            );
 
-            var hoeDirtPerformUseAction = typeof(HoeDirt).GetMethod("performUseAction");
-            var objectOverridesPerformUseAction = typeof(TransplantOverrides).GetMethod("PerformUseAction");
-            harmony.Patch(hoeDirtPerformUseAction, new HarmonyMethod(objectOverridesPerformUseAction), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(HoeDirt), nameof(HoeDirt.performUseAction)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.PerformUseAction))
+            );
 
-            var fruitTreePerformUseAction = typeof(FruitTree).GetMethod("performUseAction");
-            var transplantOverridesFruitTreePerformUseAction = typeof(TransplantOverrides).GetMethod("FruitTreePerformUseAction");
-            harmony.Patch(fruitTreePerformUseAction, null, new HarmonyMethod(transplantOverridesFruitTreePerformUseAction));
+            harmony.Patch(
+                original: AccessTools.Method(typeof(FruitTree), nameof(FruitTree.performUseAction)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.FruitTreePerformUseAction))
+            );
 
-            var game1PressUseToolButton = typeof(Game1).GetMethod("pressUseToolButton");
-            var objectOverridesPressUseToolButton = typeof(TransplantOverrides).GetMethod("PressUseToolButton");
-            harmony.Patch(game1PressUseToolButton, new HarmonyMethod(objectOverridesPressUseToolButton), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Game1), nameof(Game1.pressUseToolButton)),
+                prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.PressUseToolButton))
+            );
 
             if (DataLoader.ModConfig.EnableSoilTileUnderTrees)
             {
-                var treeDraw = typeof(Tree).GetMethod("draw");
-                var transplantOverridesPreTreeDraw = typeof(TransplantOverrides).GetMethod("PreTreeDraw");
-                harmony.Patch(treeDraw, new HarmonyMethod(transplantOverridesPreTreeDraw), null);
+                harmony.Patch(
+                    original: AccessTools.Method(typeof(Tree), nameof(Tree.draw)),
+                    prefix: new HarmonyMethod(typeof(TransplantOverrides), nameof(TransplantOverrides.PreTreeDraw))
+                );
             }
         }
 

--- a/CustomCaskMod/CustomCaskModEntry.cs
+++ b/CustomCaskMod/CustomCaskModEntry.cs
@@ -36,9 +36,10 @@ namespace CustomCaskMod
 
             var harmony = HarmonyInstance.Create("Digus.CustomCaskMod");
 
-            var caskPerformObjectDropInAction = typeof(Cask).GetMethod("performObjectDropInAction");
-            var caskOverridesPerformObjectDropInAction = typeof(CaskOverrides).GetMethod("PerformObjectDropInAction");
-            harmony.Patch(caskPerformObjectDropInAction, new HarmonyMethod(caskOverridesPerformObjectDropInAction), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Cask), nameof(Cask.performObjectDropInAction)),
+                prefix: new HarmonyMethod(typeof(CaskOverrides), nameof(CaskOverrides.PerformObjectDropInAction))
+            );
         }
     }
 }

--- a/CustomCaskMod/CustomCaskModEntry.cs
+++ b/CustomCaskMod/CustomCaskModEntry.cs
@@ -1,19 +1,38 @@
 ﻿using Harmony;
-using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley.Objects;
 
 namespace CustomCaskMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class CustomCaskModEntry : Mod
     {
         internal IMonitor ModMonitor { get; set; }
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             ModMonitor = Monitor;
-            new DataLoader(helper);
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            new DataLoader(Helper);
 
             var harmony = HarmonyInstance.Create("Digus.CustomCaskMod");
 

--- a/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
+++ b/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
@@ -1,21 +1,39 @@
 ﻿using System.Reflection;
-using CustomCrystalariumMod;
 using Harmony;
-using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 
 namespace CustomCrystalariumMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class CustomCrystalariumModEntry : Mod
     {
         public static IMonitor ModMonitor;
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             ModMonitor = Monitor;
-            new DataLoader(helper);
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            new DataLoader(Helper);
 
             var harmony = HarmonyInstance.Create("Digus.CustomCrystalariumMod");
 

--- a/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
+++ b/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
@@ -1,8 +1,7 @@
-﻿using System.Reflection;
-using Harmony;
+﻿using Harmony;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewValley;
+using SObject = StardewValley.Object;
 
 namespace CustomCrystalariumMod
 {
@@ -37,19 +36,22 @@ namespace CustomCrystalariumMod
 
             var harmony = HarmonyInstance.Create("Digus.CustomCrystalariumMod");
 
-            var objectGetMinutesForCrystalarium = typeof(Object).GetMethod("getMinutesForCrystalarium", BindingFlags.NonPublic | BindingFlags.Instance);
-            var objectOverridesGetMinutesForCrystalarium = typeof(ObjectOverrides).GetMethod("GetMinutesForCrystalarium");
-            harmony.Patch(objectGetMinutesForCrystalarium, new HarmonyMethod(objectOverridesGetMinutesForCrystalarium), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SObject), "getMinutesForCrystalarium"),
+                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.GetMinutesForCrystalarium))
+            );
 
-            var objectPerformObjectDropInAction = typeof(Object).GetMethod("performObjectDropInAction");
-            var objectOverridesPerformObjectDropInAction = typeof(ObjectOverrides).GetMethod("PerformObjectDropInAction");
-            harmony.Patch(objectPerformObjectDropInAction, new HarmonyMethod(objectOverridesPerformObjectDropInAction), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SObject), nameof(SObject.performObjectDropInAction)),
+                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.PerformObjectDropInAction))
+            );
 
             if (DataLoader.ModConfig.GetObjectBackOnChange && !DataLoader.ModConfig.GetObjectBackImmediately)
             {
-                var objectPerformRemoveAction = typeof(Object).GetMethod("performRemoveAction");
-                var objectOverridesPerformRemoveAction = typeof(ObjectOverrides).GetMethod("PerformRemoveAction");
-                harmony.Patch(objectPerformRemoveAction, new HarmonyMethod(objectOverridesPerformRemoveAction), null);
+                harmony.Patch(
+                    original: AccessTools.Method(typeof(SObject), nameof(SObject.performRemoveAction)),
+                    prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.PerformRemoveAction))
+                );
             }
         }
     }

--- a/EverlastingBaitsUnbreakableTacklesMod/Commands.cs
+++ b/EverlastingBaitsUnbreakableTacklesMod/Commands.cs
@@ -13,7 +13,7 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
 {
     public class Commands
     {
-        public static IMonitor ModMonitor = EverlastingBaitsAndUnbreakableTacklesModEntery.ModMonitor;
+        public static IMonitor ModMonitor = EverlastingBaitsAndUnbreakableTacklesModEntry.ModMonitor;
 
         public static void AddAllBaitTackleRecipes(string command, string[] args)
         {

--- a/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesMod.csproj
+++ b/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesMod.csproj
@@ -45,7 +45,7 @@
     <Compile Include="Commands.cs" />
     <Compile Include="DataLoader.cs" />
     <Compile Include="GameOverrides.cs" />
-    <Compile Include="EverlastingBaitsAndUnbreakableTacklesModEntery.cs" />
+    <Compile Include="EverlastingBaitsAndUnbreakableTacklesModEntry.cs" />
     <Compile Include="ModConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CraftingData.cs" />

--- a/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
+++ b/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
@@ -1,28 +1,52 @@
 ﻿using System.Reflection;
 using Harmony;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Tools;
 
 namespace EverlastingBaitsAndUnbreakableTacklesMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class EverlastingBaitsAndUnbreakableTacklesModEntry : Mod
     {
         public static IMonitor ModMonitor;
         internal static DataLoader DataLoader;
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             ModMonitor = Monitor;
-            DataLoader = new DataLoader(helper);
+            
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
 
-            helper.Events.GameLoop.SaveLoaded += (sender, e) => DataLoader.ReloadQuestWhenClient();
+            helper.ConsoleCommands.Add("player_addallbaitstacklesrecipes", "Add all everlasting baits and unbreakable tackles recipes to the player.", Commands.AddAllBaitTackleRecipes);
+            helper.ConsoleCommands.Add("player_getallbaitstackles", "Get all everlasting baits and unbreakable tackles.", Commands.GetAllBaitTackle);
+            helper.ConsoleCommands.Add("player_addquestfortackle", "Adds a quest for the specified unbreakable tackles.\n\nUsage: player_addsQuestForTackle <value>\n- value: name of the tackle. ex. Unbreakable Trap Bobber", Commands.AddsQuestForTackle);
+            helper.ConsoleCommands.Add("player_removeblankquests", "Remove all blank quests from player log.", Commands.RemoveBlankQuests);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            DataLoader = new DataLoader(Helper);
 
             var harmony = HarmonyInstance.Create("Digus.InfiniteBaitAndLureMod");
 
-            var fishingRodDoDoneFishing =
-                typeof(FishingRod).GetMethod("doDoneFishing", BindingFlags.NonPublic | BindingFlags.Instance);
+            var fishingRodDoDoneFishing = typeof(FishingRod).GetMethod("doDoneFishing", BindingFlags.NonPublic | BindingFlags.Instance);
             var fishingRodOverridesDoDoneFishing = typeof(GameOverrides).GetMethod("DoDoneFishing");
             harmony.Patch(fishingRodDoDoneFishing, new HarmonyMethod(fishingRodOverridesDoDoneFishing), null);
 
@@ -30,8 +54,7 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
             var fishingRodOverridesCreateItem = typeof(GameOverrides).GetMethod("CreateItem");
             harmony.Patch(craftingRecipeCreateItem, new HarmonyMethod(fishingRodOverridesCreateItem), null);
 
-            var craftingPageClickCraftingRecipe = typeof(CraftingPage).GetMethod("clickCraftingRecipe",
-                BindingFlags.NonPublic | BindingFlags.Instance);
+            var craftingPageClickCraftingRecipe = typeof(CraftingPage).GetMethod("clickCraftingRecipe", BindingFlags.NonPublic | BindingFlags.Instance);
             var gameOverridesClickCraftingRecipe = typeof(GameOverrides).GetMethod("ClickCraftingRecipe");
             harmony.Patch(craftingPageClickCraftingRecipe, new HarmonyMethod(gameOverridesClickCraftingRecipe), null);
 
@@ -41,18 +64,18 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
 
             if (!DataLoader.ModConfig.DisableIridiumQualityFish)
             {
-                var bobberBarConstructor = typeof(BobberBar).GetConstructor(new []{ typeof(int), typeof(float), typeof(bool), typeof(int)});
+                var bobberBarConstructor = typeof(BobberBar).GetConstructor(new[] { typeof(int), typeof(float), typeof(bool), typeof(int) });
                 var gameOverridesBobberBar = typeof(GameOverrides).GetMethod("BobberBar");
                 harmony.Patch(bobberBarConstructor, null, new HarmonyMethod(gameOverridesBobberBar));
             }
-
-            helper.ConsoleCommands.Add("player_addallbaitstacklesrecipes",
-                "Add all everlasting baits and unbreakable tackles recipes to the player.", Commands.AddAllBaitTackleRecipes);
-            helper.ConsoleCommands.Add("player_getallbaitstackles", "Get all everlasting baits and unbreakable tackles.", Commands.GetAllBaitTackle);
-            helper.ConsoleCommands.Add("player_addquestfortackle", "Adds a quest for the specified unbreakable tackles.\n\nUsage: player_addsQuestForTackle <value>\n- value: name of the tackle. ex. Unbreakable Trap Bobber", Commands.AddsQuestForTackle);
-            helper.ConsoleCommands.Add("player_removeblankquests", "Remove all blank quests from player log.", Commands.RemoveBlankQuests);
         }
 
-        
+        /// <summary>Raised after the player loads a save slot and the world is initialised.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            DataLoader.ReloadQuestWhenClient();
+        }
     }
 }

--- a/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
+++ b/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Harmony;
+﻿using Harmony;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -46,27 +45,33 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
 
             var harmony = HarmonyInstance.Create("Digus.InfiniteBaitAndLureMod");
 
-            var fishingRodDoDoneFishing = typeof(FishingRod).GetMethod("doDoneFishing", BindingFlags.NonPublic | BindingFlags.Instance);
-            var fishingRodOverridesDoDoneFishing = typeof(GameOverrides).GetMethod("DoDoneFishing");
-            harmony.Patch(fishingRodDoDoneFishing, new HarmonyMethod(fishingRodOverridesDoDoneFishing), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(FishingRod), "doDoneFishing"),
+                prefix: new HarmonyMethod(typeof(GameOverrides), nameof(GameOverrides.DoDoneFishing))
+            );
 
-            var craftingRecipeCreateItem = typeof(CraftingRecipe).GetMethod("createItem");
-            var fishingRodOverridesCreateItem = typeof(GameOverrides).GetMethod("CreateItem");
-            harmony.Patch(craftingRecipeCreateItem, new HarmonyMethod(fishingRodOverridesCreateItem), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(CraftingRecipe), nameof(CraftingRecipe.createItem)),
+                prefix: new HarmonyMethod(typeof(GameOverrides), nameof(GameOverrides.CreateItem))
+            );
 
-            var craftingPageClickCraftingRecipe = typeof(CraftingPage).GetMethod("clickCraftingRecipe", BindingFlags.NonPublic | BindingFlags.Instance);
-            var gameOverridesClickCraftingRecipe = typeof(GameOverrides).GetMethod("ClickCraftingRecipe");
-            harmony.Patch(craftingPageClickCraftingRecipe, new HarmonyMethod(gameOverridesClickCraftingRecipe), null);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(CraftingPage), "clickCraftingRecipe"),
+                prefix: new HarmonyMethod(typeof(GameOverrides), nameof(GameOverrides.ClickCraftingRecipe))
+            );
+            
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NPC), nameof(NPC.tryToReceiveActiveObject)),
+                prefix: new HarmonyMethod(typeof(GameOverrides), nameof(GameOverrides.TryToReceiveActiveObject))
+            );
 
-            var npcTryToReceiveActiveObject = typeof(NPC).GetMethod("tryToReceiveActiveObject");
-            var gameOverridesTryToReceiveActiveObject = typeof(GameOverrides).GetMethod("TryToReceiveActiveObject");
-            harmony.Patch(npcTryToReceiveActiveObject, new HarmonyMethod(gameOverridesTryToReceiveActiveObject), null);
 
             if (!DataLoader.ModConfig.DisableIridiumQualityFish)
             {
-                var bobberBarConstructor = typeof(BobberBar).GetConstructor(new[] { typeof(int), typeof(float), typeof(bool), typeof(int) });
-                var gameOverridesBobberBar = typeof(GameOverrides).GetMethod("BobberBar");
-                harmony.Patch(bobberBarConstructor, null, new HarmonyMethod(gameOverridesBobberBar));
+                harmony.Patch(
+                    original: AccessTools.Constructor(typeof(BobberBar), new[] { typeof(int), typeof(float), typeof(bool), typeof(int) }),
+                    postfix: new HarmonyMethod(typeof(GameOverrides), nameof(GameOverrides.BobberBar))
+                );
             }
         }
 

--- a/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
+++ b/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesModEntry.cs
@@ -7,7 +7,7 @@ using StardewValley.Tools;
 
 namespace EverlastingBaitsAndUnbreakableTacklesMod
 {
-    public class EverlastingBaitsAndUnbreakableTacklesModEntery : Mod
+    public class EverlastingBaitsAndUnbreakableTacklesModEntry : Mod
     {
         public static IMonitor ModMonitor;
         internal static DataLoader DataLoader;

--- a/MailFrameworkMod/Commands.cs
+++ b/MailFrameworkMod/Commands.cs
@@ -10,7 +10,7 @@ namespace MailFrameworkMod
 {
     public class Commands
     {
-        public static IMonitor ModMonitor = MailFrameworkModEntery.ModMonitor;
+        public static IMonitor ModMonitor = MailFrameworkModEntry.ModMonitor;
 
         public static void AddsReceivedMail(string command, string[] args)
         {

--- a/MailFrameworkMod/LetterViewerMenuExtended.cs
+++ b/MailFrameworkMod/LetterViewerMenuExtended.cs
@@ -36,9 +36,9 @@ namespace MailFrameworkMod
 
         private void initiPrivateProperties()
         {
-            _moneyIncluded = MailFrameworkModEntery.ModHelper.Reflection.GetField<int>(this, "moneyIncluded").GetValue();
-            LearnedRecipe = MailFrameworkModEntery.ModHelper.Reflection.GetField<string>(this, "learnedRecipe").GetValue();
-            CookingOrCrafting = MailFrameworkModEntery.ModHelper.Reflection.GetField<string>(this, "cookingOrCrafting").GetValue();
+            _moneyIncluded = MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(this, "moneyIncluded").GetValue();
+            LearnedRecipe = MailFrameworkModEntry.ModHelper.Reflection.GetField<string>(this, "learnedRecipe").GetValue();
+            CookingOrCrafting = MailFrameworkModEntry.ModHelper.Reflection.GetField<string>(this, "cookingOrCrafting").GetValue();
         }
 
         public static bool GetTextColor(LetterViewerMenu __instance, ref int __result)
@@ -58,11 +58,11 @@ namespace MailFrameworkMod
         {
             base.draw(b);
             
-            if ((double)MailFrameworkModEntery.ModHelper.Reflection.GetField<float>(this, "scale").GetValue() == 1.0 && this._moneyIncluded <= 0)
+            if ((double)MailFrameworkModEntry.ModHelper.Reflection.GetField<float>(this, "scale").GetValue() == 1.0 && this._moneyIncluded <= 0)
             {
                 if (!string.IsNullOrEmpty(this.LearnedRecipe))
                 {
-                    int textColor = MailFrameworkModEntery.ModHelper.Reflection.GetMethod(this, "getTextColor").Invoke<int>();
+                    int textColor = MailFrameworkModEntry.ModHelper.Reflection.GetMethod(this, "getTextColor").Invoke<int>();
                     string s = Game1.content.LoadString("Strings\\UI:LetterViewer_LearnedRecipe", (object)this.CookingOrCrafting);
                     SpriteText.drawStringHorizontallyCenteredAt(b, s, this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen + this.height - 32 - SpriteText.getHeightOfString(s, 999999) * 2, 999999, this.width - 64, 9999, 0.65f, 0.865f, false, textColor);
                     SpriteText.drawStringHorizontallyCenteredAt(b, Game1.content.LoadString("Strings\\UI:LetterViewer_LearnedRecipeName", (object)this.LearnedRecipe), this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen + this.height - 32 - SpriteText.getHeightOfString("t", 999999), 999999, this.width - 64, 9999, 0.9f, 0.865f, false, textColor);

--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -17,7 +17,7 @@ namespace MailFrameworkMod
         private static String _nextLetterId = "none";
         private static readonly List<Letter> Letters = new List<Letter>();
         private static Letter _shownLetter = null;
-        private static IModEvents _events => MailFrameworkModEntery.ModHelper.Events;
+        private static IModEvents _events => MailFrameworkModEntry.ModHelper.Events;
 
         /// <summary>
         /// Call this method to update the mail box with new letters.
@@ -93,10 +93,10 @@ namespace MailFrameworkMod
                 {
                     _shownLetter = Letters.First();
                     var activeClickableMenu = new LetterViewerMenuExtended(_shownLetter.Text.Replace("@", Game1.player.Name),_shownLetter.Id);
-                    MailFrameworkModEntery.ModHelper.Reflection.GetField<int>(activeClickableMenu,"whichBG").SetValue(_shownLetter.WhichBG);
+                    MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(activeClickableMenu,"whichBG").SetValue(_shownLetter.WhichBG);
                     if (_shownLetter.LetterTexture != null)
                     {
-                        MailFrameworkModEntery.ModHelper.Reflection.GetField<Texture2D>(activeClickableMenu, "letterTexture").SetValue(_shownLetter.LetterTexture);
+                        MailFrameworkModEntry.ModHelper.Reflection.GetField<Texture2D>(activeClickableMenu, "letterTexture").SetValue(_shownLetter.LetterTexture);
                     }
                     activeClickableMenu.TextColor = _shownLetter.TextColor;
                     
@@ -126,8 +126,8 @@ namespace MailFrameworkMod
                     if (_shownLetter.Recipe != null)
                     {
                         string recipe = _shownLetter.Recipe;
-                        Dictionary<string, string> cookingData = MailFrameworkModEntery.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CookingRecipes", ContentSource.GameContent);
-                        Dictionary<string, string> craftingData = MailFrameworkModEntery.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CraftingRecipes", ContentSource.GameContent);
+                        Dictionary<string, string> cookingData = MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CookingRecipes", ContentSource.GameContent);
+                        Dictionary<string, string> craftingData = MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CraftingRecipes", ContentSource.GameContent);
                         string recipeString = null;
                         int dataArrayI18NSize = 0;
                         string cookingOrCraftingText = null;
@@ -153,7 +153,7 @@ namespace MailFrameworkMod
                         }
                         else
                         {
-                            MailFrameworkModEntery.ModMonitor.Log($"The recipe '{recipe}' was not found. The mail will ignore it.", LogLevel.Warn);
+                            MailFrameworkModEntry.ModMonitor.Log($"The recipe '{recipe}' was not found. The mail will ignore it.", LogLevel.Warn);
                         }
 
                         if (recipeString != null)
@@ -164,7 +164,7 @@ namespace MailFrameworkMod
                                 string[] strArray = recipeString.Split('/');
                                 if (strArray.Length < dataArrayI18NSize)
                                 {
-                                    MailFrameworkModEntery.ModMonitor.Log($"The recipe '{recipe}' does not have a internationalized name. The default name will be used.", LogLevel.Warn);
+                                    MailFrameworkModEntry.ModMonitor.Log($"The recipe '{recipe}' does not have a internationalized name. The default name will be used.", LogLevel.Warn);
                                 }
                                 else
                                 {
@@ -172,11 +172,11 @@ namespace MailFrameworkMod
                                 }
                             }
 
-                            if (MailFrameworkModEntery.ModHelper.Reflection.GetMethod(activeClickableMenu, "getTextColor").Invoke<int>() == -1)
+                            if (MailFrameworkModEntry.ModHelper.Reflection.GetMethod(activeClickableMenu, "getTextColor").Invoke<int>() == -1)
                             {
-                                MailFrameworkModEntery.ModHelper.Reflection
+                                MailFrameworkModEntry.ModHelper.Reflection
                                     .GetField<String>(activeClickableMenu, "cookingOrCrafting").SetValue(cookingOrCraftingText);
-                                MailFrameworkModEntery.ModHelper.Reflection
+                                MailFrameworkModEntry.ModHelper.Reflection
                                     .GetField<String>(activeClickableMenu, "learnedRecipe").SetValue(learnedRecipe);
                             }
                             else

--- a/MailFrameworkMod/MailDao.cs
+++ b/MailFrameworkMod/MailDao.cs
@@ -52,8 +52,8 @@ namespace MailFrameworkMod
                 }
                 catch (Exception e)
                 {
-                    MailFrameworkModEntery.ModMonitor.Log($"Error while validating letter '{l.Id}'. This letter will be ignored.", LogLevel.Error);
-                    MailFrameworkModEntery.ModMonitor.Log($"Error: {e.Message}\n{e.StackTrace}", LogLevel.Trace);
+                    MailFrameworkModEntry.ModMonitor.Log($"Error while validating letter '{l.Id}'. This letter will be ignored.", LogLevel.Error);
+                    MailFrameworkModEntry.ModMonitor.Log($"Error: {e.Message}\n{e.StackTrace}", LogLevel.Trace);
                 }
 
                 return condition;

--- a/MailFrameworkMod/MailDao.cs
+++ b/MailFrameworkMod/MailDao.cs
@@ -1,9 +1,7 @@
 ﻿using StardewModdingAPI;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using StardewValley;
 
 namespace MailFrameworkMod
 {
@@ -17,6 +15,9 @@ namespace MailFrameworkMod
         /// <param name="letter"> The letter to be saved.</param>
         public static void SaveLetter(Letter letter)
         {
+            if (Game1.objectInformation == null)
+                throw new NotImplementedException("Can't add a letter before the game is launched.");
+
             if (Letters.Exists((l) => l.Id == letter.Id))
             {
                 Letters[Letters.FindIndex((l) => l.Id == letter.Id)] = letter;

--- a/MailFrameworkMod/MailFrameworkMod.csproj
+++ b/MailFrameworkMod/MailFrameworkMod.csproj
@@ -72,7 +72,7 @@
     <Compile Include="LetterViewerMenuExtended.cs" />
     <Compile Include="MailController.cs" />
     <Compile Include="MailDao.cs" />
-    <Compile Include="MailFrameworkModEntery.cs" />
+    <Compile Include="MailFrameworkModEntry.cs" />
     <Compile Include="ModConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/MailFrameworkMod/MailFrameworkModEntry.cs
+++ b/MailFrameworkMod/MailFrameworkModEntry.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Harmony;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -56,15 +53,17 @@ namespace MailFrameworkMod
             {
                 var harmony = HarmonyInstance.Create("Digus.MailFrameworkMod");
 
-                var gameLetterViewerMenuGetTextColor = typeof(LetterViewerMenu).GetMethod("getTextColor", BindingFlags.NonPublic | BindingFlags.Instance);
-                var letterViewerMenuExtendedGetTextColor = typeof(LetterViewerMenuExtended).GetMethod("GetTextColor");
-                harmony.Patch(gameLetterViewerMenuGetTextColor, new HarmonyMethod(letterViewerMenuExtendedGetTextColor), null);
+                harmony.Patch(
+                    original: AccessTools.Method(typeof(LetterViewerMenu), "getTextColor"), 
+                    prefix: new HarmonyMethod(typeof(LetterViewerMenuExtended), nameof(LetterViewerMenuExtended.GetTextColor))
+                );
 
                 if (!ModConfig.UseOldMethodOfOpeningCustomMail)
                 {
-                    var gameLocaltionMailbox = typeof(GameLocation).GetMethod("mailbox");
-                    var mailControllerMailbox = typeof(MailController).GetMethod("mailbox");
-                    harmony.Patch(gameLocaltionMailbox, new HarmonyMethod(mailControllerMailbox), null);
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.mailbox)),
+                        prefix: new HarmonyMethod(typeof(MailController), nameof(MailController.mailbox))
+                    );
                 }
                 else
                 {

--- a/MailFrameworkMod/MailFrameworkModEntry.cs
+++ b/MailFrameworkMod/MailFrameworkModEntry.cs
@@ -10,7 +10,7 @@ using StardewValley.Menus;
 
 namespace MailFrameworkMod
 {
-    public class MailFrameworkModEntery : Mod
+    public class MailFrameworkModEntry : Mod
     {
         public static IModHelper ModHelper;
         public static IMonitor ModMonitor;
@@ -59,7 +59,7 @@ namespace MailFrameworkMod
             }
             catch (Exception e)
             {
-                Monitor.Log("Erro patching the GameLocation 'mailbox' Method. Applying old method of listening to menu change events.",LogLevel.Warn);
+                Monitor.Log("Error patching the GameLocation 'mailbox' Method. Applying old method of listening to menu change events.",LogLevel.Warn);
                 Monitor.Log(e.Message+e.StackTrace,LogLevel.Trace);
                 WatchLetterMenu();
             }

--- a/MailFrameworkMod/MailFrameworkModEntry.cs
+++ b/MailFrameworkMod/MailFrameworkModEntry.cs
@@ -10,11 +10,13 @@ using StardewValley.Menus;
 
 namespace MailFrameworkMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class MailFrameworkModEntry : Mod
     {
         public static IModHelper ModHelper;
         public static IMonitor ModMonitor;
         public static ModConfig ModConfig;
+
 
         /*********
         ** Public methods
@@ -29,14 +31,26 @@ namespace MailFrameworkMod
             ModHelper = helper;
             ModMonitor = Monitor;
             ModConfig = helper.ReadConfig<ModConfig>();
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
             helper.Events.GameLoop.DayStarted += OnDayStarted;
             helper.Events.GameLoop.ReturnedToTitle += OnReturnedToTitle;
             helper.Events.GameLoop.Saving += OnSaving;
-            var editors = helper.Content.AssetEditors;
-            editors.Add(new DataLoader());
 
             helper.ConsoleCommands.Add("player_addreceivedmail", "Adds a mail as received.\n\nUsage: player_addreceivedmail <value>\n- value: name of the mail.", Commands.AddsReceivedMail);
             helper.ConsoleCommands.Add("player_removereceivedmail", "Remove a mail from the list of received mail.\n\nUsage: player_removereceivedmail <value>\n- value: name of the mail.", Commands.RemoveReceivedMail);
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            Helper.Content.AssetEditors.Add(new DataLoader());
 
             try
             {
@@ -57,10 +71,10 @@ namespace MailFrameworkMod
                     WatchLetterMenu();
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Monitor.Log("Error patching the GameLocation 'mailbox' Method. Applying old method of listening to menu change events.",LogLevel.Warn);
-                Monitor.Log(e.Message+e.StackTrace,LogLevel.Trace);
+                Monitor.Log("Error patching the GameLocation 'mailbox' Method. Applying old method of listening to menu change events.", LogLevel.Warn);
+                Monitor.Log(ex.Message + ex.StackTrace, LogLevel.Trace);
                 WatchLetterMenu();
             }
         }
@@ -95,10 +109,6 @@ namespace MailFrameworkMod
             Helper.Events.Display.MenuChanged += OnMenuChanged;
         }
 
-
-        /*********
-        ** Private methods
-        *********/
         /// <summary>
         /// Raised after the game begins a new day (including when the player loads a save).
         /// Here it updates the mail box.

--- a/WaterRetainingFieldMod/WaterRetainingFieldModEntry.cs
+++ b/WaterRetainingFieldMod/WaterRetainingFieldModEntry.cs
@@ -1,18 +1,37 @@
 ﻿using Harmony;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using StardewValley.TerrainFeatures;
 
 namespace WaterRetainingFieldMod
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class WaterRetainingFieldModEntry : Mod
     {
         internal static DataLoader DataLoader;
 
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            DataLoader = new DataLoader(helper);
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.DayStarted += OnDayStarted;
+        }
 
-            helper.Events.GameLoop.DayStarted += (sender, e) => HoeDirtOverrides.TileLocationState.Clear();
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            DataLoader = new DataLoader(Helper);
 
             var harmony = HarmonyInstance.Create("Digus.WaterRetainingFieldMod");
 
@@ -20,6 +39,14 @@ namespace WaterRetainingFieldMod
             var hoeDirtOverridesDayUpdatePrefix = typeof(HoeDirtOverrides).GetMethod("DayUpdatePrefix");
             var hoeDirtOverridesDayUpdatePostfix = typeof(HoeDirtOverrides).GetMethod("DayUpdatePostfix");
             harmony.Patch(hoeDirtDayUpdate, new HarmonyMethod(hoeDirtOverridesDayUpdatePrefix), new HarmonyMethod(hoeDirtOverridesDayUpdatePostfix));
+        }
+
+        /// <summary>Raised after the game begins a new day (including when the player loads a save).</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnDayStarted(object sender, DayStartedEventArgs e)
+        {
+            HoeDirtOverrides.TileLocationState.Clear();
         }
     }
 }

--- a/WaterRetainingFieldMod/WaterRetainingFieldModEntry.cs
+++ b/WaterRetainingFieldMod/WaterRetainingFieldModEntry.cs
@@ -35,10 +35,11 @@ namespace WaterRetainingFieldMod
 
             var harmony = HarmonyInstance.Create("Digus.WaterRetainingFieldMod");
 
-            var hoeDirtDayUpdate = typeof(HoeDirt).GetMethod("dayUpdate");
-            var hoeDirtOverridesDayUpdatePrefix = typeof(HoeDirtOverrides).GetMethod("DayUpdatePrefix");
-            var hoeDirtOverridesDayUpdatePostfix = typeof(HoeDirtOverrides).GetMethod("DayUpdatePostfix");
-            harmony.Patch(hoeDirtDayUpdate, new HarmonyMethod(hoeDirtOverridesDayUpdatePrefix), new HarmonyMethod(hoeDirtOverridesDayUpdatePostfix));
+            harmony.Patch(
+                original: AccessTools.Method(typeof(HoeDirt), nameof(HoeDirt.dayUpdate)),
+                prefix: new HarmonyMethod(typeof(HoeDirtOverrides), nameof(HoeDirtOverrides.DayUpdatePrefix)),
+                postfix: new HarmonyMethod(typeof(HoeDirtOverrides), nameof(HoeDirtOverrides.DayUpdatePostfix))
+            );
         }
 
         /// <summary>Raised after the game begins a new day (including when the player loads a save).</summary>


### PR DESCRIPTION
SMAPI 3.0 will load mods much earlier, so `Entry` will be called before the game is fully initialised. This PR updates the code to handle that (should work fine in 2.11 too).

Changes in this pull request:
* Updated for SMAPI 3.0 loading mods earlier.
* Simplified Harmony patching code, and made it easier to detect breaking game changes (e.g. using `nameof` where possible so compile fails if the method is renamed).
* Fixed two typos (_Entery_ → _Entry_, and _Erro_ → _Error_).

Let me know if you want me to change anything!