### PR TITLE
Animal Husbandry 2.4.2-beta3

### DIFF
--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -9,6 +9,7 @@ using AnimalHusbandryMod.meats;
 using AnimalHusbandryMod.tools;
 using Harmony;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using PyTK.CustomElementHandler;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -179,6 +180,11 @@ namespace AnimalHusbandryMod
                     harmony.Patch(
                         original: AccessTools.Method(typeof(Pet), nameof(Pet.update), new[] { typeof(GameTime), typeof(GameLocation) }),
                         prefix: new HarmonyMethod(typeof(PetOverrides), nameof(PetOverrides.update))
+                    );
+
+                    harmony.Patch(
+                        original: AccessTools.Method(typeof(Pet), nameof(Pet.draw), new[] { typeof(SpriteBatch) }),
+                        prefix: new HarmonyMethod(typeof(PetOverrides), nameof(PetOverrides.draw))
                     );
                 }
 

--- a/ButcherMod/animals/AnimalContestController.cs
+++ b/ButcherMod/animals/AnimalContestController.cs
@@ -163,7 +163,7 @@ namespace AnimalHusbandryMod.animals
                     {
                         if (participated)
                         {
-                            Pet pet = ((Pet)Game1.getCharacterFromName(Game1.player.getPetName()));
+                            Pet pet = Game1.player.getPet();
                             pet.friendshipTowardFarmer.Value = Math.Min(Pet.maxFriendship, pet.friendshipTowardFarmer.Value + DataLoader.AnimalContestData.PetFriendshipForParticipating);
                         }
                         AnimalContestController.ReAddPet();
@@ -207,7 +207,7 @@ namespace AnimalHusbandryMod.animals
 
         public static void TemporalyRemovePet()
         {
-            Game1.getCharacterFromName(Game1.player.getPetName()).IsInvisible = true;
+            Game1.player.getPet().IsInvisible = true;
         }
 
         public static void ReAddFarmAnimal(long participantIdValue)
@@ -221,7 +221,7 @@ namespace AnimalHusbandryMod.animals
 
         public static void ReAddPet()
         {
-            Game1.getCharacterFromName(Game1.player.getPetName()).IsInvisible = false;
+            Game1.player.getPet().IsInvisible = false;
         }
 
         public static void CleanTemporaryParticipant()

--- a/ButcherMod/animals/PetOverrides.cs
+++ b/ButcherMod/animals/PetOverrides.cs
@@ -62,5 +62,14 @@ namespace AnimalHusbandryMod.animals
             }
             return true;
         }
+
+        public static bool draw(Pet __instance)
+        {
+            if (__instance.IsInvisible)
+            {
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/ButcherMod/common/EventOverrides.cs
+++ b/ButcherMod/common/EventOverrides.cs
@@ -557,10 +557,13 @@ namespace AnimalHusbandryMod.common
 
         public static void skipEvent(Event __instance)
         {
-            AnimalContestItem lastAnimalContest = FarmerLoader.FarmerData.AnimalContestData.LastOrDefault();
-            if (lastAnimalContest != null && lastAnimalContest.EventId == __instance.id)
+            if (FarmerLoader.FarmerData != null)
             {
-                AnimalContestController.EndEvent(lastAnimalContest);
+                AnimalContestItem lastAnimalContest = FarmerLoader.FarmerData.AnimalContestData.LastOrDefault();
+                if (lastAnimalContest != null && lastAnimalContest.EventId == __instance.id)
+                {
+                    AnimalContestController.EndEvent(lastAnimalContest);
+                }
             }
         }
 

--- a/ButcherMod/manifest.json
+++ b/ButcherMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Animal Husbandry Mod",
    "Author": "Digus",
-   "Version": "2.4.2-beta2",
+   "Version": "2.4.2-beta3",
    "Description": "Adds features related to animal husbandry.",
    "UniqueID": "DIGUS.ANIMALHUSBANDRYMOD",
    "EntryDll": "AnimalHusbandryMod.dll",


### PR DESCRIPTION
- Fix to Pets not working in the contest.
- Fix to Pets not being properly invisible before going to the contest.
- Fix to error in the log when skipping certain events.