### PR TITLE
Mail Framework Mod - 1.5.1

### DIFF
--- a/MailFrameworkMod/ContentPack/ItemType.cs
+++ b/MailFrameworkMod/ContentPack/ItemType.cs
@@ -4,6 +4,7 @@
     {
         Object,
         Tool,
-        BigObject
+        BigObject,
+        BigCraftable
     }
 }

--- a/MailFrameworkMod/ContentPack/MailItem.cs
+++ b/MailFrameworkMod/ContentPack/MailItem.cs
@@ -5,6 +5,7 @@ namespace MailFrameworkMod.ContentPack
     public class MailItem
     {
         public string Id;
+        public string GroupId;
         public string Title;
         public string Text;
         public string Recipe;
@@ -18,5 +19,6 @@ namespace MailFrameworkMod.ContentPack
         public string Weather;
         public List<FriendshipCondition> FriendshipConditions;
         public List<SkillCondition> SkillConditions;
+        public double? RandomChance;
     }
 }

--- a/MailFrameworkMod/ContentPackTemplate/mail.json
+++ b/MailFrameworkMod/ContentPackTemplate/mail.json
@@ -1,25 +1,27 @@
 [
 	{
-		"Id": "MyMod.MyMailId", // Letter id. It's importent to be an unique string to avoid conflicts.
-		"Title": "My Letter Title", // Letter title. Will be shown in the collections menu. (Unimplemented Yet)
-		"Text": "Dear @^This is my custom mail.", // Text of the letter. You can use @ to put the players name and ^ for line breakes. You can also use the base game commands to add money, itens and stuff.
-		"Attachments": [{"Type": "Tool", "Name": "Axe"},{"Type": "Object", "Index":78, "Stack": 3},{"Type": "BigObject", "Index":159}], // Remove the line to not attach items to the mail. You can use the Name properties for Object and BigObject items too, that's required if using Json Assets. Stack is required for all Object items.
+		"Id": "MyMod.MyMailId", // Letter id. It's important to be an unique string to avoid conflicts. Also it shouldn't have space characters.
+		"GroupId": "MyMod.MyGroupId", // Letter group id. Letters with the same group id are never delivered in the same day. It can be null or removed.
+		"Title": "My Letter Title", // Letter title. Will be shown in the collections menu. Set it null or remove the line if you don't want the letter to appear in the collection.
+		"Text": "Dear @^This is my custom mail.", // Text of the letter. You can use @ to put the players name and ^ for line breaks. You can also use the base game commands to add money, items and stuff.
+		"Attachments": [{"Type": "Tool", "Name": "Axe"},{"Type": "Object", "Index":78, "Stack": 1},{"Type": "BigCraftable", "Index":159, "Stack": 3}], // Remove the line to not attach items to the mail. You can use the Name properties for Object and BigCraftable items too, that's required if using Json Assets. Stack is optional o Objects and BigCraftable. A stack of 1 is used if none is provided.
 		"Recipe": "Recipe Name", // Remove the line if you don't want to attach a recipe to the mail. It will only work if you have no other attachments to the mail.
-		"WhichBG": 0, //The id of the letter background. 0 = classic, 1 = notepad, 2 = piramds
+		"WhichBG": 0, //The id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
 		"TextColor": -1, //Remove this line to use the default color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
 		"Repeatable": false, // If true the mod won't check it the letter Id has already been delivered.
 		//Below are conditions for the delivery. Remove any of the lines if you don't want to check that condition.
 		"Date": "10 spring Y1", // Must be that date or after it. The format is "[1-28] [spring|summer|fall|winter] Y[1-999]".
-		"Days":  [7,14,21,28], // Must be one of the days in the list.
-		"Seasons":  ["fall"], // Must be one of the seasons in the list, seasons should be lower case.
-		"Weather":  "sunny", // Must me that game weather. The format is "[sunny|rainy]".
+		"Days": [7,14,21,28], // Must be one of the days in the list.
+		"Seasons": ["fall"], // Must be one of the seasons in the list, seasons should be lower case.
+		"Weather": "sunny", // Must me that game weather. The format is "[sunny|rainy]".
 		"FriendshipConditions": // Each NPC of the list must have a friendship level equal or higher what is defined. Can use custom NPCs
 		[
 			{ "NpcName": "Lewis", "FriendshipLevel": 0 }
 		],
-		"SkillConditions": // Each skill of the list must have a level equal or higher what is defined. Can use all coded skills in the valina game, including Luck. Can't use custom skills.
+		"SkillConditions": // Each skill of the list must have a level equal or higher what is defined. Can use all coded skills in the vanilla game, including Luck. Can't use custom skills.
 		[
 			{ "SkillName": "Farming", "SkillLevel": 1 }
-		]
+		],
+		"RandomChance": 0.25 // The mod will check if a random number from 0 to 1 is bellow the given number. The same save, on the same day for the same letter will always have the same result to avoid cheating.
 	}
 ]

--- a/MailFrameworkMod/Letter.cs
+++ b/MailFrameworkMod/Letter.cs
@@ -10,12 +10,17 @@ namespace MailFrameworkMod
 {
     public class Letter
     {
+        private string _id;
         /// <summary>
         /// this letter unique id
         /// </summary>
-        public string Id { get; private set; }
+        public string Id { get => _id; private set => _id = value.Replace(" ",""); }
         /// <summary>
-        /// this letter title to be show in the collections menu (Unimplemented Yet)
+        /// this letter group id
+        /// </summary>
+        public string GroupId;
+        /// <summary>
+        /// this letter title to be show in the collections menu
         /// </summary>
         public string Title;
         /// <summary>

--- a/MailFrameworkMod/LetterViewerMenuExtended.cs
+++ b/MailFrameworkMod/LetterViewerMenuExtended.cs
@@ -29,7 +29,7 @@ namespace MailFrameworkMod
             initiPrivateProperties();
         }
 
-        public LetterViewerMenuExtended(string mail, string mailTitle) : base(mail, mailTitle)
+        public LetterViewerMenuExtended(string mail, string mailTitle, bool fromCollection = false) : base(mail, mailTitle, fromCollection)
         {
             initiPrivateProperties();
         }

--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -96,7 +96,7 @@ namespace MailFrameworkMod
                     MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(activeClickableMenu,"whichBG").SetValue(_shownLetter.WhichBG);
                     if (_shownLetter.LetterTexture != null)
                     {
-                        MailFrameworkModEntry.ModHelper.Reflection.GetField<Texture2D>(activeClickableMenu, "letterTexture").SetValue(_shownLetter.LetterTexture);
+                        activeClickableMenu.letterTexture = _shownLetter.LetterTexture;
                     }
                     activeClickableMenu.TextColor = _shownLetter.TextColor;
                     
@@ -258,6 +258,36 @@ namespace MailFrameworkMod
                 else
                 {
                     _events.Display.MenuChanged += OnMenuChanged;
+                }
+            }
+            return true;
+        }
+
+        public static bool receiveLeftClick(CollectionsPage __instance, int x, int y)
+        {
+            int currentTab = MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(__instance, "currentTab").GetValue();
+
+            if (__instance.letterviewerSubMenu == null && currentTab == 7)
+            {
+                int currentPage = MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(__instance, "currentPage").GetValue();
+                foreach (ClickableTextureComponent clickableComponent in __instance.collections[currentTab][currentPage])
+                {
+                    if (clickableComponent.containsPoint(x, y))
+                    {
+                        Letter letter = MailDao.FindLetter(clickableComponent.name.Split(' ')[0]);
+                        if (letter != null)
+                        {
+                            LetterViewerMenuExtended letterViewerMenu = new LetterViewerMenuExtended(letter.Text.Replace("@", Game1.player.Name), letter.Id, true);
+                            MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(letterViewerMenu, "whichBG").SetValue(letter.WhichBG);
+                            if (letter.LetterTexture != null)
+                            {
+                                letterViewerMenu.letterTexture = letter.LetterTexture;
+                            }
+                            letterViewerMenu.TextColor = letter.TextColor;
+                            __instance.letterviewerSubMenu = letterViewerMenu;
+                            return false;
+                        }
+                    }
                 }
             }
             return true;

--- a/MailFrameworkMod/MailFrameworkModEntry.cs
+++ b/MailFrameworkMod/MailFrameworkModEntry.cs
@@ -45,6 +45,7 @@ namespace MailFrameworkMod
         /// <param name="e">The event data.</param>
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            Helper.Content.AssetEditors.Add(new DataLoader());
             var harmony = HarmonyInstance.Create("Digus.MailFrameworkMod");
 
             harmony.Patch(
@@ -55,6 +56,11 @@ namespace MailFrameworkMod
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.mailbox)),
                 prefix: new HarmonyMethod(typeof(MailController), nameof(MailController.mailbox))
+            );
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(CollectionsPage), nameof(CollectionsPage.receiveLeftClick)),
+                prefix: new HarmonyMethod(typeof(MailController), nameof(MailController.receiveLeftClick))
             );
         }
 
@@ -88,6 +94,10 @@ namespace MailFrameworkMod
         /// <param name="e">The event arguments.</param>
         private void OnDayStarted(object sender, DayStartedEventArgs e)
         {
+            if (MailDao.HasRepositoryChanged())
+            {
+                Helper.Content.InvalidateCache("Data\\mail");
+            }
             MailController.UpdateMailBox();
 
         }

--- a/MailFrameworkMod/manifest.json
+++ b/MailFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
 	"Name": "Mail Framework Mod",
 	"Author": "Digus",
-	"Version": "1.4.1",
+	"Version": "1.5.1",
 	"MinimumApiVersion": "3.0.0",
 	"Description": "Utility classes to send mail in the game.",
 	"UniqueID": "DIGUS.MailFrameworkMod",


### PR DESCRIPTION
Mail Framework Mod - 1.5.0
- Letter can now have Title and GroupId.
- Letter with Title are loaded in the game mail data, using the new game syntax for titles.
- Letter with the same group id are grouped when validating and only the first one is sent.
- Content Pack now have a Random Chance condition. It creates a seed based on the game day, game unique id and letter unique id, to avoid cheating.
- Removing Reelection for letter texture now that it's public.
- Letter can now be opened in the Collection Page, with their custom texture and text color.
- Keeping track of mail repository changes to correctly update mail data.
- Invalidate cache of mail in the begin of the day if Letter repository has changed.
- BigObject should now be BigCraftable. Both are accepted for now.
- Template updated.

Mail Framework Mod - 1.5.1
- Fix to group id grouping letter with null group id.