### PR TITLE
Animal Husbandry Mod 2.4.2-beta6

### DIFF
--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -63,7 +63,14 @@ namespace AnimalHusbandryMod
             else
             {
                 DataLoader = new DataLoader(Helper);
-                DataLoader.LoadContentPacksCommand();
+                try
+                {
+                    DataLoader.LoadContentPacksCommand();
+                }
+                catch (Exception ex)
+                {
+                    Monitor.Log($"Error while trying to load the content packs. Your custom animals might not work as intended.\n{ex}",LogLevel.Error);
+                }
 
                 if (!DataLoader.ModConfig.DisableMeat)
                 {

--- a/ButcherMod/common/DataLoader.cs
+++ b/ButcherMod/common/DataLoader.cs
@@ -366,24 +366,45 @@ namespace AnimalHusbandryMod.common
 
         public void LoadContentPacksCommand(string command = null, string[] args = null)
         {
-            foreach (IContentPack contentPack in Helper.ContentPacks.GetOwned())
+            try
             {
-                if (File.Exists(Path.Combine(contentPack.DirectoryPath, "customAnimals.json")))
+                foreach (IContentPack contentPack in Helper.ContentPacks.GetOwned())
                 {
-                    AnimalHusbandryModEntry.monitor.Log($"Reading content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}");
-                    List<CustomAnimalItem> customAnimalItems = contentPack.ReadJsonFile<List<CustomAnimalItem>>("customAnimals.json");
-                    foreach (CustomAnimalItem customAnimalItem in customAnimalItems)
+                    try
                     {
-                        DataLoader.AnimalData.CustomAnimals.RemoveAll(c => c.Name.Contains(customAnimalItem.Name));
-                        DataLoader.AnimalData.CustomAnimals.Add(customAnimalItem);
+                        if (File.Exists(Path.Combine(contentPack.DirectoryPath, "customAnimals.json")))
+                        {
+                            AnimalHusbandryModEntry.monitor.Log(
+                                $"Reading content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}");
+                            List<CustomAnimalItem> customAnimalItems = contentPack.ReadJsonFile<List<CustomAnimalItem>>("customAnimals.json");
+                            foreach (CustomAnimalItem customAnimalItem in customAnimalItems)
+                            {
+                                DataLoader.AnimalData.CustomAnimals.RemoveAll(c => c.Name.Contains(customAnimalItem.Name));
+                                DataLoader.AnimalData.CustomAnimals.Add(customAnimalItem);
+                            }
+                        }
+                        else
+                        {
+                            AnimalHusbandryModEntry.monitor
+                                .Log(
+                                    $"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\n" +
+                                    $"It does not have an customAnimals.json file."
+                                    , LogLevel.Warn);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        AnimalHusbandryModEntry.monitor
+                            .Log(
+                                $"Error while trying to load the content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}. It'll be ignored.\n{ex}"
+                                , LogLevel.Error);
                     }
                 }
-                else
-                {
-                    AnimalHusbandryModEntry.monitor.Log($"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an customAnimals.json file.", LogLevel.Warn);
-                }
             }
-            AnimalData.FillLikedTreatsIds();
+            finally
+            {
+                AnimalData.FillLikedTreatsIds();
+            }
         }
 
         enum Taste {

--- a/ButcherMod/manifest.json
+++ b/ButcherMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Animal Husbandry Mod",
    "Author": "Digus",
-   "Version": "2.4.2-beta5",
+   "Version": "2.4.2-beta6",
    "Description": "Adds features related to animal husbandry.",
    "UniqueID": "DIGUS.ANIMALHUSBANDRYMOD",
    "EntryDll": "AnimalHusbandryMod.dll",


### PR DESCRIPTION
- Fix to fertility bonus with auto-grabber in the coop.
- The fix is done by checking if there is a object in the animal position to avoid error. The case where it was placed inside the auto-grabber is handled by a transpiler code that set the stack of the object being added to two.
- Better error handling of content pack loading.