### PR TITLE
Producer Framework Mod 1.4.2

### DIFF
--- a/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
+++ b/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
@@ -1,10 +1,8 @@
-﻿using System;
+﻿using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Controllers;
+using StardewModdingAPI;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ProducerFrameworkMod.ContentPack;
-using StardewModdingAPI;
 using Object = StardewValley.Object;
 
 namespace ProducerFrameworkMod.Api

--- a/ProducerFrameworkMod/ContentPack/ProducerConfig.cs
+++ b/ProducerFrameworkMod/ContentPack/ProducerConfig.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Remoting.Messaging;
+using ProducerFrameworkMod.Controllers;
+using ProducerFrameworkMod.Utils;
 using StardewValley;
 
 namespace ProducerFrameworkMod.ContentPack

--- a/ProducerFrameworkMod/ContentPackTemplate/ProducerRules.json
+++ b/ProducerFrameworkMod/ContentPackTemplate/ProducerRules.json
@@ -11,8 +11,8 @@
 			"Coal": 1,
 			"246": 5
 		}, //Additional fuel if needed. You don't need to set a Fuel to use AdditionalFuel. The format is a pair of identifier and stack amount, following the same rules of the other fuel property. Default is null.
-		"MinutesUntilReady": 120, //The amount of minutes it takes to produce. Should be divisible by 10. Required.
-		"SubtractTimeOfDay": true, //If MinutesUntilReady should be subtracted by the current time of day.
+		"MinutesUntilReady": 120, //The amount of minutes it takes to produce. Stardew days have 1600 minutes. 1200 minutes from 6 am to 2am and 400 minutes from 2am to 6am. Should be divisible by 10. Required.
+		"SubtractTimeOfDay": true, //If MinutesUntilReady should be subtracted by the current time of day. It always add 360 to the formula, since the day start at 6 am. So if you set MinutesUntilReady to 1600, it will always produce at 6 am of the next day. Never set to true if MinutesUntilReady is smaller than 1600.
 		"OutputIdentifier": "Beer", //The identifier of the output. Can be the Index or the Name of the object. Required.
 		"OutputName": "{farmerName}'s {inputName} {outputName} from {farmName}", //The Name of the object. This will replace the basic output name. It accepts 4 tags that are dynamically replaced. Default is null.
 		"OutputTranslationKey": "MyMod.MyOutput", //The translation key. This is the key in the i18n file where the mod will look for the format of the OutputName in other languages. The value of this key follows the same rules of the OutputName property above. Default is null.

--- a/ProducerFrameworkMod/Controllers/AnimationController.cs
+++ b/ProducerFrameworkMod/Controllers/AnimationController.cs
@@ -2,7 +2,7 @@ using Microsoft.Xna.Framework;
 using ProducerFrameworkMod.ContentPack;
 using StardewValley;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     internal class AnimationController
     {

--- a/ProducerFrameworkMod/Controllers/LightSourceConfigController.cs
+++ b/ProducerFrameworkMod/Controllers/LightSourceConfigController.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using ProducerFrameworkMod.ContentPack;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Objects;
 using Object = StardewValley.Object;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     public class LightSourceConfigController
     {

--- a/ProducerFrameworkMod/Controllers/OutputConfigController.cs
+++ b/ProducerFrameworkMod/Controllers/OutputConfigController.cs
@@ -1,16 +1,16 @@
-﻿
+﻿using Microsoft.Xna.Framework;
+using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Utils;
+using StardewValley;
+using StardewValley.Menus;
+using StardewValley.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.Xna.Framework;
-using ProducerFrameworkMod.ContentPack;
-using StardewValley;
-using StardewValley.Menus;
-using StardewValley.Objects;
 using Object = StardewValley.Object;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     public class OutputConfigController
     {

--- a/ProducerFrameworkMod/Controllers/ProducerController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerController.cs
@@ -1,16 +1,13 @@
-﻿using System;
+﻿using Microsoft.Xna.Framework;
+using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Utils;
+using StardewModdingAPI;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Remoting.Messaging;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Xna.Framework;
-using ProducerFrameworkMod.ContentPack;
-using StardewModdingAPI;
-using StardewValley;
 using Object = StardewValley.Object;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     public class ProducerController
     {

--- a/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Utils;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.BellsAndWhistles;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Object = StardewValley.Object;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     public class ProducerRuleController
     {
@@ -106,7 +105,7 @@ namespace ProducerFrameworkMod
                     producer.minutesUntilReady.Value = outputConfig.MinutesUntilReady ?? producerRule.MinutesUntilReady;
                     if (producerRule.SubtractTimeOfDay)
                     {
-                        producer.minutesUntilReady.Value = Math.Max(producer.minutesUntilReady.Value - Game1.timeOfDay, 1);
+                        producer.minutesUntilReady.Value = Math.Max(producer.minutesUntilReady.Value - Utility.ConvertTimeToMinutes(Game1.timeOfDay) + 360, 1);
                     }
 
                     if (producerConfig != null)

--- a/ProducerFrameworkMod/Controllers/StatsController.cs
+++ b/ProducerFrameworkMod/Controllers/StatsController.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ProducerFrameworkMod.ContentPack;
+﻿using ProducerFrameworkMod.ContentPack;
 using StardewValley;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Controllers
 {
     public class StatsController
     {

--- a/ProducerFrameworkMod/DataLoader.cs
+++ b/ProducerFrameworkMod/DataLoader.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Controllers;
+using StardewModdingAPI;
+using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ProducerFrameworkMod.ContentPack;
-using StardewModdingAPI;
+using StardewModdingAPI.Events;
 
 namespace ProducerFrameworkMod
 {
@@ -27,9 +26,9 @@ namespace ProducerFrameworkMod
             {
                 string producersConfigJson = GetActualCaseForFileName(contentPack.DirectoryPath, ProducersConfigJson);
                 bool haveProducersConfigFile = producersConfigJson != null;
+                ProducerFrameworkModEntry.ModMonitor.Log($"Reading content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}");
                 if (haveProducersConfigFile)
                 {
-                    ProducerFrameworkModEntry.ModMonitor.Log($"Reading content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}");
                     List<ProducerConfig> producersConfigs = contentPack.ReadJsonFile<List<ProducerConfig>>(producersConfigJson);
                     ProducerController.AddProducersConfig(producersConfigs, contentPack.Manifest.UniqueID);
                 }
@@ -38,22 +37,24 @@ namespace ProducerFrameworkMod
                     ProducerFrameworkModEntry.ModMonitor.Log($"Content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an {ProducersConfigJson} file.", LogLevel.Trace);
                 }
 
-                string producerRulesJson = GetActualCaseForFileName(contentPack.DirectoryPath, ProducerRulesJson);
-                bool haveProducerRulesFile = producerRulesJson != null;
-                if (haveProducerRulesFile)
+                if (e is SaveLoadedEventArgs)
                 {
-                    ProducerFrameworkModEntry.ModMonitor.Log($"Reading content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}");
-                    List<ProducerRule> producerItems = contentPack.ReadJsonFile<List<ProducerRule>>(producerRulesJson);
-                    ProducerController.AddProducerItems(producerItems, contentPack.Translation);
-                }
-                else
-                {
-                    ProducerFrameworkModEntry.ModMonitor.Log($"Content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an {ProducerRulesJson} file.", LogLevel.Trace);
-                }
+                    string producerRulesJson = GetActualCaseForFileName(contentPack.DirectoryPath, ProducerRulesJson);
+                    bool haveProducerRulesFile = producerRulesJson != null;
+                    if (haveProducerRulesFile)
+                    {
+                        List<ProducerRule> producerItems = contentPack.ReadJsonFile<List<ProducerRule>>(producerRulesJson);
+                        ProducerController.AddProducerItems(producerItems, contentPack.Translation);
+                    }
+                    else
+                    {
+                        ProducerFrameworkModEntry.ModMonitor.Log($"Content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an {ProducerRulesJson} file.", LogLevel.Trace);
+                    }
 
-                if (!haveProducerRulesFile && !haveProducersConfigFile)
-                {
-                    ProducerFrameworkModEntry.ModMonitor.Log($"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have any of the required files.", LogLevel.Warn);
+                    if (!haveProducerRulesFile && !haveProducersConfigFile)
+                    {
+                        ProducerFrameworkModEntry.ModMonitor.Log($"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have any of the required files.", LogLevel.Warn);
+                    }
                 }
             }
         }

--- a/ProducerFrameworkMod/ObjectOverrides.cs
+++ b/ProducerFrameworkMod/ObjectOverrides.cs
@@ -1,17 +1,16 @@
-﻿using System;
+﻿using Harmony;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using ProducerFrameworkMod.ContentPack;
+using ProducerFrameworkMod.Controllers;
+using ProducerFrameworkMod.Utils;
+using StardewValley;
+using StardewValley.Network;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text.RegularExpressions;
-using Harmony;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using Netcode;
-using ProducerFrameworkMod.ContentPack;
-using StardewValley;
-using StardewValley.Network;
-using StardewValley.Objects;
-using StardewValley.TerrainFeatures;
 using Object = StardewValley.Object;
 
 namespace ProducerFrameworkMod
@@ -235,7 +234,7 @@ namespace ProducerFrameworkMod
                 linkedListNode.Value = new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ObjectOverrides), "getScale", new Type[] {typeof(Object)}));
             }
 
-            codeInstruction = newInstructions.FirstOrDefault(c => c.opcode == OpCodes.Callvirt && c.operand?.ToString() == "Void Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Rectangle, System.Nullable`1[Microsoft.Xna.Framework.Rectangle], Microsoft.Xna.Framework.Color, Single, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Graphics.SpriteEffects, Single)");
+            codeInstruction = newInstructions.LastOrDefault(c => c.opcode == OpCodes.Callvirt && c.operand?.ToString() == "Void Draw(Microsoft.Xna.Framework.Graphics.Texture2D, Microsoft.Xna.Framework.Rectangle, System.Nullable`1[Microsoft.Xna.Framework.Rectangle], Microsoft.Xna.Framework.Color, Single, Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework.Graphics.SpriteEffects, Single)");
             linkedListNode = newInstructions.Find(codeInstruction);
             if (linkedListNode != null && codeInstruction != null)
             {
@@ -251,10 +250,6 @@ namespace ProducerFrameworkMod
             if(ProducerController.GetProducerConfig(__instance.Name) is ProducerConfig producerConfig && __instance.MinutesUntilReady > 0 && __instance.heldObject.Value != null)
             {
                 if (producerConfig.DisableBouncingAnimationWhileWorking)
-                {
-                    return Vector2.Zero;
-                }
-                else if (!producerConfig.CheckLocationCondition(Game1.currentLocation))
                 {
                     return Vector2.Zero;
                 }
@@ -288,7 +283,8 @@ namespace ProducerFrameworkMod
         {
             if (ProducerController.GetProducerConfig(producer.Name) is ProducerConfig producerConfig)
             {
-                if (producerConfig.ProducingAnimation is Animation producingAnimation && producer.minutesUntilReady > 0 && producingAnimation.RelativeFrameIndex.Any())
+                if (producerConfig.ProducingAnimation is Animation producingAnimation && producer.minutesUntilReady > 0 && producingAnimation.RelativeFrameIndex.Any()
+                    && producerConfig.CheckSeasonCondition() && producerConfig.CheckWeatherCondition() && producerConfig.CheckCurrentTimeCondition())
                 {
                     int frame = producingAnimation.RelativeFrameIndex[((Game1.ticks + GetLocationSeed(producer.TileLocation)) % (producingAnimation.RelativeFrameIndex.Count * producingAnimation.FrameInterval)) / producingAnimation.FrameInterval];
                     spriteBatch.Draw(texture, destinationRectangle, new Rectangle?(Object.getSourceRectForBigCraftable(producer.ParentSheetIndex + frame)), color, rotation, origin, effects, layerDepth);

--- a/ProducerFrameworkMod/ProducerFrameworkMod.csproj
+++ b/ProducerFrameworkMod/ProducerFrameworkMod.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AnimationController.cs" />
+    <Compile Include="Controllers\AnimationController.cs" />
     <Compile Include="Api\IProducerFrameworkModAPI.cs" />
     <Compile Include="Api\ProducerFrameworkModApi.cs" />
     <Compile Include="ContentPack\Animation.cs" />
@@ -69,19 +69,19 @@
     <Compile Include="ContentPack\Weather.cs" />
     <Compile Include="ContentPack\WorkingTime.cs" />
     <Compile Include="DataLoader.cs" />
-    <Compile Include="GameUtils.cs" />
-    <Compile Include="LightSourceConfigController.cs" />
+    <Compile Include="Utils\GameUtils.cs" />
+    <Compile Include="Controllers\LightSourceConfigController.cs" />
     <Compile Include="ObjectOverrides.cs" />
-    <Compile Include="ObjectUtils.cs" />
-    <Compile Include="OutputConfigController.cs" />
-    <Compile Include="ProducerController.cs" />
+    <Compile Include="Utils\ObjectUtils.cs" />
+    <Compile Include="Controllers\OutputConfigController.cs" />
+    <Compile Include="Controllers\ProducerController.cs" />
     <Compile Include="ProducerFrameworkModEntry.cs" />
-    <Compile Include="ProducerRuleController.cs" />
+    <Compile Include="Controllers\ProducerRuleController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="NameUtils.cs" />
+    <Compile Include="Utils\NameUtils.cs" />
     <Compile Include="RestrictionException.cs" />
-    <Compile Include="SoundUtil.cs" />
-    <Compile Include="StatsController.cs" />
+    <Compile Include="Utils\SoundUtil.cs" />
+    <Compile Include="Controllers\StatsController.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ContentPackTemplate\manifest.json">
@@ -107,6 +107,7 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/ProducerFrameworkMod/ProducerFrameworkModEntry.cs
+++ b/ProducerFrameworkMod/ProducerFrameworkModEntry.cs
@@ -19,6 +19,7 @@ namespace ProducerFrameworkMod
             Helper = helper;
             
             helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.GameLaunched += DataLoader.LoadContentPacks;
             helper.Events.GameLoop.SaveLoaded += DataLoader.LoadContentPacks;
         }
 
@@ -28,7 +29,7 @@ namespace ProducerFrameworkMod
         /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
-        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        private void OnGameLaunched(object sender, EventArgs e)
         {
             new DataLoader(Helper);
 

--- a/ProducerFrameworkMod/Utils/GameUtils.cs
+++ b/ProducerFrameworkMod/Utils/GameUtils.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ProducerFrameworkMod.ContentPack;
+﻿using ProducerFrameworkMod.ContentPack;
 using StardewValley;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Utils
 {
     public class GameUtils
     {

--- a/ProducerFrameworkMod/Utils/NameUtils.cs
+++ b/ProducerFrameworkMod/Utils/NameUtils.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewValley;
+using System.Collections.Generic;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Utils
 {
     internal class NameUtils
     {

--- a/ProducerFrameworkMod/Utils/ObjectUtils.cs
+++ b/ProducerFrameworkMod/Utils/ObjectUtils.cs
@@ -1,6 +1,6 @@
 ﻿using StardewValley;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Utils
 {
     internal class ObjectUtils
     {

--- a/ProducerFrameworkMod/Utils/SoundUtil.cs
+++ b/ProducerFrameworkMod/Utils/SoundUtil.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Network;
+using System;
+using System.Collections.Generic;
 
-namespace ProducerFrameworkMod
+namespace ProducerFrameworkMod.Utils
 {
     internal class SoundUtil
     {

--- a/ProducerFrameworkMod/manifest.json
+++ b/ProducerFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Producer Framework Mod",
   "Author": "Digus",
-  "Version": "1.4.1",
+  "Version": "1.4.2",
   "Description": "Framework to add rules to produce objects or change the vanilla rules.",
   "UniqueID": "Digus.ProducerFrameworkMod",
   "EntryDll": "ProducerFrameworkMod.dll",


### PR DESCRIPTION
- Loading ProducersConfig on mod loading to avoid light source not being created when loading the fist save.
- Fix to draw transpiler. The point of identification got a similar call after 1.5, so a change was needed to patch the right place.
- Checking for producing conditions when drawing animation.
- Fix to the way SubtractTimeOfDay was working. It was not converting string time to minutes, and not adjusting for the day starting time.
- Changing or namespace to better organize classes.
- Won't check for location condition on draw cycle, since location can't change after the producing has started.