### PR TITLE
Custom Producer Mod 1.2.2

### DIFF
--- a/CustomProducerMod/ProducerRules.json
+++ b/CustomProducerMod/ProducerRules.json
@@ -449,7 +449,7 @@
     },
     { //Mushroom
         "ProducerName": "Mushroom Box",
-        "MinutesUntilReady": 3000,
+        "MinutesUntilReady": 3200,
         "SubtractTimeOfDay": true,
         "OutputIdentifier": "404",
         "AdditionalOutputs": [
@@ -473,7 +473,7 @@
     },
     { //Bait
         "ProducerName": "Worm Bin",
-        "MinutesUntilReady": 2600,
+        "MinutesUntilReady": 1600,
         "SubtractTimeOfDay": true,
         "OutputIdentifier": "685",
         "OutputStack": 2,
@@ -493,7 +493,7 @@
     },
     { // Honey
         "ProducerName": "Bee House",
-        "MinutesUntilReady": 6720,
+        "MinutesUntilReady": 6400,
         "SubtractTimeOfDay": true,
         "OutputIdentifier": "340",
         "InputPriceBased": true,

--- a/CustomProducerMod/manifest.json
+++ b/CustomProducerMod/manifest.json
@@ -1,13 +1,13 @@
 ﻿{
   "Name": "[PFM]Custom Producer Mod",
   "Author": "Digus",
-  "Version": "1.2.1",
+  "Version": "1.2.2",
   "Description": "This content pack contain the default implementation of vanilla machines supported by Custom Producer Mod. It should work as base for people to change the vanilla machines behavior.",
   "UniqueID": "Digus.CustomProducerMod",
   "MinimumApiVersion": "3.0.0",
   "UpdateKeys": [ "Nexus:4992" ],
   "Dependencies": [
-	  { "UniqueID": "Digus.ProducerFrameworkMod", "MinimumVersion": "1.4.0" }
+	  { "UniqueID": "Digus.ProducerFrameworkMod", "MinimumVersion": "1.4.2" }
   ],
   "ContentPackFor": {
     "UniqueID": "Digus.ProducerFrameworkMod"


### PR DESCRIPTION
- update to support PFM 1.4.2
- fix time to complete for machines that subtract time of the day, considering the fixed logic of PFM.