### PR TITLE
Add API method to allow mods to directly add content packs

### DIFF
--- a/BorderlessWoodFloorMod/BorderlessWoodFloorMod.csproj
+++ b/BorderlessWoodFloorMod/BorderlessWoodFloorMod.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/ButcherMod/AnimalHusbandryMod.csproj
+++ b/ButcherMod/AnimalHusbandryMod.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <GamePath>I:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
+    <EnableHarmony>true</EnableHarmony>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -53,11 +53,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.2.0.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="PyTK">
       <HintPath>$(GamePath)\Mods\PyTK\PyTK.dll</HintPath>
       <Private>False</Private>

--- a/CropTransplantMod/CropTransplantMod.csproj
+++ b/CropTransplantMod/CropTransplantMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CropTransplantMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,11 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/CustomCaskMod/CustomCaskMod.csproj
+++ b/CustomCaskMod/CustomCaskMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CustomCaskMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,10 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/CustomCrystalariumMod/CustomCrystalariumMod.csproj
+++ b/CustomCrystalariumMod/CustomCrystalariumMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CustomCrystalariumMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -33,10 +34,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />

--- a/CustomKissingMod/CustomKissingMod.csproj
+++ b/CustomKissingMod/CustomKissingMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>CustomKissingMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -32,10 +33,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesMod.csproj
+++ b/EverlastingBaitsUnbreakableTacklesMod/EverlastingBaitsAndUnbreakableTacklesMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>EverlastingBaitsAndUnbreakableTacklesMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,10 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/MailFrameworkMod/MailFrameworkMod.csproj
+++ b/MailFrameworkMod/MailFrameworkMod.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <GamePath>I:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -51,11 +51,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=1.1.0.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/PFMAutomate/PFMAutomate.csproj
+++ b/PFMAutomate/PFMAutomate.csproj
@@ -14,6 +14,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,12 +36,8 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Automate">
-      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\Mods\Automate\Automate.dll</HintPath>
+      <HintPath>$(GamePath)\Mods\Automate\Automate.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/ProducerFrameworkMod/Api/IProducerFrameworkModAPI.cs
+++ b/ProducerFrameworkMod/Api/IProducerFrameworkModAPI.cs
@@ -52,5 +52,13 @@ namespace ProducerFrameworkMod.Api
         /// <param name="producerObject">The Stardew Valley Object for the producer.</param>
         /// <returns>The list of producer rules</returns>
         List<ProducerRule> GetProducerRules(SObject producerObject);
+
+        /// <summary>
+        /// Adds a content pack from the specified directory.
+        /// This method expects a content-pack.json file instead of a manifest.json
+        /// </summary>
+        /// <param name="directory">The absolute path of the content pack.</param>
+        /// <returns>true if the content pack was successfully loaded, otherwise false.</returns>
+        bool AddContentPack(string directory);
     }
 }

--- a/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
+++ b/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
@@ -1,8 +1,10 @@
 ﻿using ProducerFrameworkMod.ContentPack;
 using ProducerFrameworkMod.Controllers;
 using StardewModdingAPI;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Object = StardewValley.Object;
 
 namespace ProducerFrameworkMod.Api
@@ -144,6 +146,25 @@ namespace ProducerFrameworkMod.Api
         public List<ProducerRule> GetProducerRules(Object producerObject)
         {
             return GetProducerRules(producerObject.Name);
+        }
+
+        public bool AddContentPack(string directory)
+        {
+            Regex nameToId = new Regex("[^a-zA-Z0-9_.]");
+            // read initial info
+            IContentPack temp = ProducerFrameworkModEntry.Helper.ContentPacks.CreateFake(directory);
+            ManifestData info = temp.ReadJsonFile<ManifestData>("content-pack.json");
+            if (info == null)
+            {
+                ProducerFrameworkModEntry.ModMonitor.Log($"\tNo {directory}/content-pack.json!", LogLevel.Warn);
+                return false;
+            }
+
+            // load content pack
+            string id = info.UniqueID ?? nameToId.Replace(info.Name, "");
+            IContentPack contentPack = ProducerFrameworkModEntry.Helper.ContentPacks.CreateTemporary(directory, id, info.Name, info.Description, info.Author, new SemanticVersion(info.Version));
+            DataLoader.LoadContentPack(contentPack, EventArgs.Empty);
+            return true;
         }
     }
 }

--- a/ProducerFrameworkMod/ContentPack/ManifestData.cs
+++ b/ProducerFrameworkMod/ContentPack/ManifestData.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProducerFrameworkMod.ContentPack
+{
+    public class ManifestData
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Version { get; set; }
+        public string Author { get; set; }
+        public string UniqueID { get; set; }
+        public IList<string> UpdateKeys { get; set; } = new List<string>();
+    }
+
+}

--- a/ProducerFrameworkMod/ProducerFrameworkMod.csproj
+++ b/ProducerFrameworkMod/ProducerFrameworkMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>ProducerFrameworkMod</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -35,10 +36,6 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\..\..\Users\Digus\.nuget\packages\newtonsoft.json\12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/ProducerFrameworkMod/ProducerFrameworkMod.csproj
+++ b/ProducerFrameworkMod/ProducerFrameworkMod.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>ProducerFrameworkMod</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-	<EnableHarmony>true</EnableHarmony>
+    <EnableHarmony>true</EnableHarmony>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContentPack\ManifestData.cs" />
     <Compile Include="Controllers\AnimationController.cs" />
     <Compile Include="Api\IProducerFrameworkModAPI.cs" />
     <Compile Include="Api\ProducerFrameworkModApi.cs" />

--- a/WaterRetainingFieldMod/WaterRetainingFieldMod.csproj
+++ b/WaterRetainingFieldMod/WaterRetainingFieldMod.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>WaterRetainingFieldMod</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+	<EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,10 +32,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>$(GamePath)\smapi-internal\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
This method is based on a similar one available JsonAssets, which allows compiled mods to directly add a content pack. This allows for mods to dynamically create producers and rules at start-up (writing them out to a temp directory) and load them directly into PFM.

I also updated the csproj files to use the <EnableHarmony> tags available in recent versions of SMAPI, as well as removing some hard-coded references which caused me some problems when initially loading the solution.