### PR TITLE
Mail Framework Mod 1.10.0

### DIFF
--- a/MailFrameworkMod/ContentPack/MailItem.cs
+++ b/MailFrameworkMod/ContentPack/MailItem.cs
@@ -35,5 +35,6 @@ namespace MailFrameworkMod.ContentPack
         public List<string> RecipeKnown;
         public bool RequireAllRecipeKnown;
         public List<string> RecipeNotKnown;
+        public bool AutoOpen;
     }
 }

--- a/MailFrameworkMod/ContentPackTemplate/mail.json
+++ b/MailFrameworkMod/ContentPackTemplate/mail.json
@@ -6,14 +6,15 @@
 		"Text": "Dear @^This is my custom mail.", // Text of the letter. You can use @ to put the players name and ^ for line breaks. You can also use the base game commands to add money, items and stuff. If an translation file is provide, you should put a translation key here.
 		"Attachments": [ // List of attachments. Remove the property to not attach items to the mail.
 			{
-				"Type": "Tool", // [Object|BigCraftable|Tool|Ring|Furniture|Weapon|Boots] Required. The type of item that will be attached. If not provided the item will be ignored.
-				"Name": "Axe", // Used to find the item index. That's required if using custom objects like Json Assets ones. Default is null.
-				"UpgradeLevel": 1 // The upgrade level of the tool. 0 = stone, 1 = cooper, 2 = steel, 3 = gold, 4 = iridium. Ignored for the other types. Default is 0. 
+				"Type": "Object", // [Object|BigCraftable|Tool|Ring|Furniture|Weapon|Boots] Required. The type of item that will be attached. If not provided the item will be ignored.
+				"Name": "Cave Carrot", // Used to find the item index. That's required if using custom objects like Json Assets ones. If not provided, the index will be used. Default is null.
+				"Index": 78, // The index of an item. If no name is provided or an item for the name is not found, the index is used. Otherwise, the attachment is ignored.
+				"Stack": 1 // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
 			},
 			{
-				"Type": "Object",
-				"Index": 78, // The index of item. If not provided and no index if found for the name, the attachment is ignored.
-				"Stack": 1 // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
+				"Type": "Tool", // When using tool, only supported ones can be attached.
+				"Name": "Axe", // [Axe|Hoe|Watering Can|Pickaxe|Scythe|Golden Scythe|Milk Pail|Shears|Fishing Rod|Pan|Return Scepter] Required for tools. The name of the supported tool. Otherwise, the attachment is ignored.
+				"UpgradeLevel": 1 // The upgrade level of the tool. Regular tools: 0 = stone, 1 = cooper, 2 = steel, 3 = gold, 4 = iridium. Fishing Rod: 0 = Bamboo Pole, 1 = Training Rod, 2 = Fiberglass Rod, 3 = Iridium Rod. Ignored for the other types. Default is 0. 
 			}
 		],
 		"Recipe": "Recipe Name", // Remove the line if you don't want to attach a recipe to the mail. It will only work if you have no other attachments to the mail.
@@ -22,7 +23,8 @@
 		"TextColor": -1, //Remove this line to use the default color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
 		"UpperRightCloseButton": "CustomCloseButton.png", // Name of the file in your content pack that has the custom close button to use. It should be 12 x 12 . If null or removed it will use the default button.
         "Repeatable": false, // If true the mod won't check it the letter Id has already been delivered. Default is false.
-		// CONDITIONS FOR DELIVERY
+		"AutoOpen":  false, // If true the mod will open the letter at the begin of the day after the conditions are met. The letter id will be marked as read and if there is a recipe set, it will be learned. Since the letter will never show, visual properties like title, text, background... will never be used, as well as the attachments.
+        // CONDITIONS FOR DELIVERY
         //Below are conditions for the delivery. Remove any of the lines if you don't want to check that condition.
 		"Date": "10 spring Y1", // Must be that date or after it. The format is "[1-28] [spring|summer|fall|winter] Y[1-999]".
 		"Days": [7,14,21,28], // Must be one of the days in the list.

--- a/MailFrameworkMod/Letter.cs
+++ b/MailFrameworkMod/Letter.cs
@@ -53,7 +53,7 @@ namespace MailFrameworkMod
         /// </summary>
         public Action<Letter> Callback { get; set; }
         /// <summary>
-        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = piramds
+        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
         /// </summary>
         public int WhichBG;
         /// <summary>
@@ -64,8 +64,14 @@ namespace MailFrameworkMod
         /// number of the text color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
         /// </summary>
         public int? TextColor;
-
+        /// <summary>
+        /// custom texture to replace the game default close button. must follow the same proportions
+        /// </summary>
         public Texture2D UpperRightCloseButtonTexture;
+        /// <summary>
+        /// when conditions are met any recipe will be learned and the callback will be called. the letter won't show in the mailbox
+        /// </summary>
+        public bool AutoOpen;
 
         /// <summary>
         /// Creates a letter.

--- a/MailFrameworkMod/LetterViewerMenuExtended.cs
+++ b/MailFrameworkMod/LetterViewerMenuExtended.cs
@@ -15,62 +15,15 @@ namespace MailFrameworkMod
     {
         public int? TextColor { get; set; }
 
-        private int _moneyIncluded;
-        public string LearnedRecipe { get; set; }
-        public string CookingOrCrafting { get; set; }
+        public LetterViewerMenuExtended(string text) : base(text) {}
 
-        public LetterViewerMenuExtended(string text) : base(text)
-        {
-            initiPrivateProperties();
-        }
+        public LetterViewerMenuExtended(int secretNoteIndex) : base(secretNoteIndex) {}
 
-        public LetterViewerMenuExtended(int secretNoteIndex) : base(secretNoteIndex)
-        {
-            initiPrivateProperties();
-        }
+        public LetterViewerMenuExtended(string mail, string mailTitle, bool fromCollection = false) : base(mail, mailTitle, fromCollection) {}
 
-        public LetterViewerMenuExtended(string mail, string mailTitle, bool fromCollection = false) : base(mail, mailTitle, fromCollection)
+        public override int getTextColor()
         {
-            initiPrivateProperties();
-        }
-
-        private void initiPrivateProperties()
-        {
-            _moneyIncluded = MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(this, "moneyIncluded").GetValue();
-            LearnedRecipe = MailFrameworkModEntry.ModHelper.Reflection.GetField<string>(this, "learnedRecipe").GetValue();
-            CookingOrCrafting = MailFrameworkModEntry.ModHelper.Reflection.GetField<string>(this, "cookingOrCrafting").GetValue();
-        }
-
-        public static bool GetTextColor(LetterViewerMenu __instance, ref int __result)
-        {
-            if (__instance is LetterViewerMenuExtended letterViewerMenuExtended && letterViewerMenuExtended.TextColor.HasValue)
-            {
-                __result = (int)letterViewerMenuExtended.TextColor;
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
-
-        public override void draw(SpriteBatch b)
-        {
-            base.draw(b);
-            
-            if ((double)MailFrameworkModEntry.ModHelper.Reflection.GetField<float>(this, "scale").GetValue() == 1.0 && this._moneyIncluded <= 0)
-            {
-                if (!string.IsNullOrEmpty(this.LearnedRecipe))
-                {
-                    int textColor = MailFrameworkModEntry.ModHelper.Reflection.GetMethod(this, "getTextColor").Invoke<int>();
-                    string s = Game1.content.LoadString("Strings\\UI:LetterViewer_LearnedRecipe", (object)this.CookingOrCrafting);
-                    SpriteText.drawStringHorizontallyCenteredAt(b, s, this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen + this.height - 32 - SpriteText.getHeightOfString(s, 999999) * 2, 999999, this.width - 64, 9999, 0.65f, 0.865f, false, textColor);
-                    SpriteText.drawStringHorizontallyCenteredAt(b, Game1.content.LoadString("Strings\\UI:LetterViewer_LearnedRecipeName", (object)this.LearnedRecipe), this.xPositionOnScreen + this.width / 2, this.yPositionOnScreen + this.height - 32 - SpriteText.getHeightOfString("t", 999999), 999999, this.width - 64, 9999, 0.9f, 0.865f, false, textColor);
-                    if (Game1.options.hardwareCursor)
-                        return;
-                    b.Draw(Game1.mouseCursors, new Vector2((float)Game1.getMouseX(), (float)Game1.getMouseY()), new Rectangle?(Game1.getSourceRectForStandardTileSheet(Game1.mouseCursors, 0, 16, 16)), Color.White, 0.0f, Vector2.Zero, (float)(4.0 + (double)Game1.dialogueButtonScale / 150.0), SpriteEffects.None, 1f);
-                }
-            }
+            return TextColor ?? base.getTextColor();
         }
 
         public override void receiveLeftClick(int x, int y, bool playSound = true)

--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -40,7 +40,15 @@ namespace MailFrameworkMod
                 IList<string> mailbox = new List<string>(Game1.player.mailbox);
                 newLetters.ForEach((l) =>
                 {
-                    Letters.Value.Add(l);
+                    if (l.AutoOpen)
+                    {
+                        if (l.Recipe != null) GetAndLearnRecipe(l.Recipe, out var s, out var i, out var t);
+                        l.Callback?.Invoke(l);
+                    }
+                    else
+                    {
+                        Letters.Value.Add(l);
+                    }
                 });
                 Letters.Value.ForEach((l) =>
                 {
@@ -193,35 +201,7 @@ namespace MailFrameworkMod
                 if (ShownLetter.Value.Recipe != null)
                 {
                     string recipe = ShownLetter.Value.Recipe;
-                    Dictionary<string, string> cookingData = MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CookingRecipes", ContentSource.GameContent);
-                    Dictionary<string, string> craftingData = MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CraftingRecipes", ContentSource.GameContent);
-                    string recipeString = null;
-                    int dataArrayI18NSize = 0;
-                    string cookingOrCraftingText = null;
-                    if (cookingData.ContainsKey(recipe))
-                    {
-                        if (!Game1.player.cookingRecipes.ContainsKey(recipe))
-                        {
-                            Game1.player.cookingRecipes.Add(recipe, 0);
-                        }
-                        recipeString = cookingData[recipe];
-                        dataArrayI18NSize = 5;
-                        cookingOrCraftingText = Game1.content.LoadString("Strings\\UI:LearnedRecipe_cooking");
-                    }
-                    else if (craftingData.ContainsKey(recipe))
-                    {
-                        if (!Game1.player.craftingRecipes.ContainsKey(recipe))
-                        {
-                            Game1.player.craftingRecipes.Add(recipe, 0);
-                        }
-                        recipeString = craftingData[recipe];
-                        dataArrayI18NSize = 6;
-                        cookingOrCraftingText = Game1.content.LoadString("Strings\\UI:LearnedRecipe_crafting");
-                    }
-                    else
-                    {
-                        MailFrameworkModEntry.ModMonitor.Log($"The recipe '{recipe}' was not found. The mail will ignore it.", LogLevel.Warn);
-                    }
+                    GetAndLearnRecipe(recipe, out string recipeString, out int dataArrayI18NSize, out string cookingOrCraftingText);
 
                     if (recipeString != null)
                     {
@@ -238,17 +218,8 @@ namespace MailFrameworkMod
                                 learnedRecipe = strArray[strArray.Length - 1];
                             }
                         }
-
-                        if (MailFrameworkModEntry.ModHelper.Reflection.GetMethod(activeClickableMenu, "getTextColor").Invoke<int>() == -1)
-                        {
-                            MailFrameworkModEntry.ModHelper.Reflection.GetField<String>(activeClickableMenu, "cookingOrCrafting").SetValue(cookingOrCraftingText);
-                            MailFrameworkModEntry.ModHelper.Reflection.GetField<String>(activeClickableMenu, "learnedRecipe").SetValue(learnedRecipe);
-                        }
-                        else
-                        {
-                            activeClickableMenu.CookingOrCrafting = cookingOrCraftingText;
-                            activeClickableMenu.LearnedRecipe = learnedRecipe;
-                        }
+                        activeClickableMenu.cookingOrCrafting = cookingOrCraftingText;
+                        activeClickableMenu.learnedRecipe = learnedRecipe;
                     }
                 }
                 activeClickableMenu.exitFunction = (IClickableMenu.onExit)Delegate.Combine(activeClickableMenu.exitFunction, (IClickableMenu.onExit)delegate
@@ -259,6 +230,47 @@ namespace MailFrameworkMod
             else
             {
                 UpdateNextLetterId();
+            }
+        }
+
+        private static void GetAndLearnRecipe(string recipe, out string recipeString, out int dataArrayI18NSize,
+            out string cookingOrCraftingText)
+        {
+            Dictionary<string, string> cookingData =
+                MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CookingRecipes",
+                    ContentSource.GameContent);
+            Dictionary<string, string> craftingData =
+                MailFrameworkModEntry.ModHelper.Content.Load<Dictionary<string, string>>("Data\\CraftingRecipes",
+                    ContentSource.GameContent);
+            recipeString = null;
+            dataArrayI18NSize = 0;
+            cookingOrCraftingText = null;
+            if (cookingData.ContainsKey(recipe))
+            {
+                if (!Game1.player.cookingRecipes.ContainsKey(recipe))
+                {
+                    Game1.player.cookingRecipes.Add(recipe, 0);
+                }
+
+                recipeString = cookingData[recipe];
+                dataArrayI18NSize = 5;
+                cookingOrCraftingText = Game1.content.LoadString("Strings\\UI:LearnedRecipe_cooking");
+            }
+            else if (craftingData.ContainsKey(recipe))
+            {
+                if (!Game1.player.craftingRecipes.ContainsKey(recipe))
+                {
+                    Game1.player.craftingRecipes.Add(recipe, 0);
+                }
+
+                recipeString = craftingData[recipe];
+                dataArrayI18NSize = 6;
+                cookingOrCraftingText = Game1.content.LoadString("Strings\\UI:LearnedRecipe_crafting");
+            }
+            else
+            {
+                MailFrameworkModEntry.ModMonitor.Log($"The recipe '{recipe}' was not found. The mail will ignore it.",
+                    LogLevel.Warn);
             }
         }
 
@@ -332,7 +344,7 @@ namespace MailFrameworkMod
                     if (clickableComponent.containsPoint(x, y))
                     {
                         Letter letter = MailDao.FindLetter(clickableComponent.name.Split(' ')[0]);
-                        if (letter != null)
+                        if (letter != null && !letter.AutoOpen)
                         {
                             LetterViewerMenuExtended letterViewerMenu = new LetterViewerMenuExtended(letter.Text.Replace("@", Game1.player.Name), letter.Id, true);
                             MailFrameworkModEntry.ModHelper.Reflection.GetField<int>(letterViewerMenu, "whichBG").SetValue(letter.WhichBG);

--- a/MailFrameworkMod/MailFrameworkModEntry.cs
+++ b/MailFrameworkMod/MailFrameworkModEntry.cs
@@ -47,11 +47,6 @@ namespace MailFrameworkMod
         {
             Helper.Content.AssetEditors.Add(new DataLoader());
             var harmony = HarmonyInstance.Create("Digus.MailFrameworkMod");
-
-            harmony.Patch(
-                original: AccessTools.Method(typeof(LetterViewerMenu), "getTextColor"), 
-                prefix: new HarmonyMethod(typeof(LetterViewerMenuExtended), nameof(LetterViewerMenuExtended.GetTextColor))
-            );
             
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.mailbox)),

--- a/MailFrameworkMod/manifest.json
+++ b/MailFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
 	"Name": "Mail Framework Mod",
 	"Author": "Digus",
-	"Version": "1.9.2",
+	"Version": "1.10.0",
 	"MinimumApiVersion": "3.9.0",
 	"Description": "Utility classes to send mail in the game.",
 	"UniqueID": "DIGUS.MailFrameworkMod",


### PR DESCRIPTION
- Support to all vanilla tools
- Support to Slingshots as weapons
- Log when an invalid attachment type is used
- Auto open property to learn the recipe and call the callback function without placing the letter in the mailbox
- Validation to ignore null attachments.
- Refectory to remove reflection from LetterViewerMenuExtended since the properties and methods used are now public.