### PR TITLE
Mail Framework Mod 1.10.2

### DIFF
--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -215,7 +215,7 @@ namespace MailFrameworkMod
                                 MailFrameworkModEntry.ModMonitor.Log($"The recipe '{recipe}' does not have a internationalized name. The default name will be used.", LogLevel.Warn);
                             }
                         }
-                        else
+                        else if (strArray[strArray.Length - 1] != "null")
                         {
                             learnedRecipe = strArray[strArray.Length - 1];
                         }

--- a/MailFrameworkMod/manifest.json
+++ b/MailFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
 	"Name": "Mail Framework Mod",
 	"Author": "Digus",
-	"Version": "1.10.1",
+	"Version": "1.10.2",
 	"MinimumApiVersion": "3.9.0",
 	"Description": "Utility classes to send mail in the game.",
 	"UniqueID": "DIGUS.MailFrameworkMod",


### PR DESCRIPTION
- Fix to null cooking recipe names because JA is adding a "/null" at the end of English recipes, that shouldn't be there.