### PR TITLE
Producer Framework Mod 1.7.2

### DIFF
--- a/ProducerFrameworkMod/Controllers/OutputConfigController.cs
+++ b/ProducerFrameworkMod/Controllers/OutputConfigController.cs
@@ -263,9 +263,12 @@ namespace ProducerFrameworkMod.Controllers
                 output.preservedParentSheetIndex.Value = input == null ? -1 : outputConfig.KeepInputParentIndex && input.preservedParentSheetIndex.Value != 0 ? input.preservedParentSheetIndex.Value : input.ParentSheetIndex;
             }
 
-            output.AddCustomName(outputConfig);
-            output.AddGenericParentName(outputConfig);
-            output.AddContentPackUniqueID(outputConfig);
+            if (outputName != null)
+            {
+                output.AddCustomName(outputConfig);
+                output.AddGenericParentName(outputConfig);
+                output.AddContentPackUniqueID(outputConfig);
+            }
 
             //Called just to load the display name.
             string loadingDisplayName = output.DisplayName;

--- a/ProducerFrameworkMod/Utils/ObjectTranslationExtension.cs
+++ b/ProducerFrameworkMod/Utils/ObjectTranslationExtension.cs
@@ -16,7 +16,7 @@ namespace ProducerFrameworkMod.Utils
 
         internal static void AddCustomName(this SObject obj, OutputConfig outputConfig)
         {
-            obj.modData[OutputTranslationKey] = outputConfig.OutputTranslationKey ?? obj.Name;
+            obj.modData[OutputTranslationKey] = outputConfig.OutputTranslationKey ?? outputConfig.OutputName;
         }
 
         internal static void AddGenericParentName(this SObject obj, OutputConfig outputConfig)

--- a/ProducerFrameworkMod/manifest.json
+++ b/ProducerFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Producer Framework Mod",
   "Author": "Digus",
-  "Version": "1.7.1",
+  "Version": "1.7.2",
   "Description": "Framework to add rules to produce objects or change the vanilla rules.",
   "UniqueID": "Digus.ProducerFrameworkMod",
   "EntryDll": "ProducerFrameworkMod.dll",


### PR DESCRIPTION
- Fixing to only adding translation keys to an object if there is a OutputName defined. This way JA translation can work when there is no configuration for names in PFM.
- Fix to add the OutputName, and not the translated name when there is no translation key.