### PR TITLE
Custom Crystalarium Mod 1.4.0

### DIFF
--- a/CustomCrystalariumMod/ClonerController.cs
+++ b/CustomCrystalariumMod/ClonerController.cs
@@ -35,7 +35,11 @@ namespace CustomCrystalariumMod
             }
             else if (customCloner.CloningDataId.ContainsKey(clonable.Category))
             {
-                return  customCloner.CloningDataId[clonable.Category];
+                return customCloner.CloningDataId[clonable.Category];
+            }
+            else if (customCloner.EnableCloneEveryObject)
+            {
+                return customCloner.DefaultCloningTime;
             }
             return null;
         }

--- a/CustomCrystalariumMod/CustomCloner.cs
+++ b/CustomCrystalariumMod/CustomCloner.cs
@@ -13,6 +13,8 @@ namespace CustomCrystalariumMod
         public bool GetObjectBackOnChange;
         public bool GetObjectBackImmediately;
         public bool BlockChange;
+        public bool EnableCloneEveryObject;
+        public int DefaultCloningTime = 5000;
         public bool UsePfmForInput;
         public Dictionary<object, int> CloningData;
         public Dictionary<int, int> CloningDataId = new Dictionary<int, int>();

--- a/CustomCrystalariumMod/CustomCrystalariumMod.csproj
+++ b/CustomCrystalariumMod/CustomCrystalariumMod.csproj
@@ -25,14 +25,4 @@
   <ItemGroup>
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\MailFrameworkMod\MailFrameworkMod.csproj">
-      <Project>{9ab101dd-fb56-4441-8180-783405d2d2f0}</Project>
-      <Name>MailFrameworkMod</Name>
-      <Private>False</Private>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
 </Project>

--- a/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
+++ b/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
@@ -56,6 +56,11 @@ namespace CustomCrystalariumMod
                 original: AccessTools.Method(typeof(SObject), nameof(SObject.performRemoveAction)),
                 prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.PerformRemoveAction)) { priority = Priority.HigherThanNormal }
             );
+            
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SObject), nameof(SObject.performToolAction)),
+                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.PerformToolAction)) { priority = Priority.HigherThanNormal }
+            );
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(SObject), nameof(SObject.checkForAction)),

--- a/CustomCrystalariumMod/DataLoader.cs
+++ b/CustomCrystalariumMod/DataLoader.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using CustomCrystalariumMod.integrations;
-using MailFrameworkMod;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
 using StardewValley;
@@ -22,7 +21,7 @@ namespace CustomCrystalariumMod
         internal static Dictionary<object,int> CrystalariumData = new Dictionary<object, int>();
 
         public const string ClonersDataJson = "ClonersData.json";
-        public const string CrystalariumDataJson = "data\\CrystalariumData.json";
+        public const string CrystalariumDataJson = "data/CrystalariumData.json";
         public static Dictionary<object, int> DefaultCystalariumData = new Dictionary<object, int>() { { 74, 20160 } };
 
         public DataLoader(IModHelper helper, IManifest manifest)
@@ -34,7 +33,7 @@ namespace CustomCrystalariumMod
             CrystalariumData = Helper.Data.ReadJsonFile<Dictionary<object, int>>(CrystalariumDataJson) ?? DefaultCystalariumData;
             Helper.Data.WriteJsonFile(CrystalariumDataJson, CrystalariumData);
 
-            Dictionary<int, string> objects = Helper.GameContent.Load<Dictionary<int, string>>(PathUtilities.NormalizeAssetName("Data\\ObjectInformation"));
+            Dictionary<int, string> objects = Helper.GameContent.Load<Dictionary<int, string>>(PathUtilities.NormalizeAssetName("Data/ObjectInformation"));
             CrystalariumData.ToList().ForEach(d =>
             {
                 int? id = GetId(d.Key, objects);
@@ -43,22 +42,19 @@ namespace CustomCrystalariumMod
 
             DataLoader.LoadContentPacksCommand();
 
-            if (!ModConfig.DisableLetter)
-            {
-                MailDao.SaveLetter
-                (
-                    new Letter
-                    (
-                        "CustomCrystalarium"
-                        , I18N.Get("CustomCrystalarium.Letter")
-                        , (l) => !Game1.player.mailReceived.Contains(l.Id) && Game1.player.stats.PrismaticShardsFound > 0
-                        , (l) => Game1.player.mailReceived.Add(l.Id)
-                    )
-                    {
-                        Title = I18N.Get("CustomCrystalarium.Letter.Title")
-                    }
-                );
-            }
+            IMailFrameworkModApi mailFrameworkModApi = helper.ModRegistry.GetApi<IMailFrameworkModApi>("DIGUS.MailFrameworkMod");
+            mailFrameworkModApi?.RegisterLetter(
+                new ApiLetter
+                {
+                    Id = "CustomCrystalarium"
+                    , Text = "CustomCrystalarium.Letter"
+                    , Title = "CustomCrystalarium.Letter.Title"
+                    , I18N = helper.Translation
+                }
+                , (l) => !ModConfig.DisableLetter && !Game1.player.mailReceived.Contains(l.Id) && Game1.player.stats.PrismaticShardsFound > 0
+                , (l) => Game1.player.mailReceived.Add(l.Id)
+            );
+
             CreateConfigMenu(manifest);
         }
 
@@ -144,6 +140,10 @@ namespace CustomCrystalariumMod
 
                 api.RegisterSimpleOption(manifest, "Disable Letter", "You won't receive the letter about how the Crystalarium can clone Prismatic Shards and can be tuned to clone more stuff. Needs to restart.", () => DataLoader.ModConfig.DisableLetter, (bool val) => DataLoader.ModConfig.DisableLetter = val);
 
+                api.RegisterSimpleOption(manifest, "Clone Every Object", "Crystalarium will be able to clone every object.", () => DataLoader.ModConfig.EnableCrystalariumCloneEveryObject, (bool val) => DataLoader.ModConfig.EnableCrystalariumCloneEveryObject = val);
+
+                api.RegisterSimpleOption(manifest, "Default Cloning Time", "Cloning time in minutes that will be used for non declared objects.", () => DataLoader.ModConfig.DefaultCloningTime, (int val) => DataLoader.ModConfig.DefaultCloningTime = val);
+
                 api.RegisterSimpleOption(manifest, "Override Cloner Config", "If checked the mod will use the below properties instead of the ones defined for each cloner.", () => DataLoader.ModConfig.OverrideContentPackGetObjectProperties, (bool val) => DataLoader.ModConfig.OverrideContentPackGetObjectProperties = val);
 
                 api.RegisterSimpleOption(manifest, "Block Change", "You won't be able to change the object inside. You will need to remove the cloner from the ground.", () => DataLoader.ModConfig.BlockChange, (bool val) => DataLoader.ModConfig.BlockChange = val);
@@ -153,7 +153,6 @@ namespace CustomCrystalariumMod
                 api.RegisterSimpleOption(manifest, "On Change", "Get the object back when changing the object being cloned or removing the cloner from the ground.", () => DataLoader.ModConfig.GetObjectBackOnChange, (bool val) => DataLoader.ModConfig.GetObjectBackOnChange = val);
 
                 api.RegisterSimpleOption(manifest, "Immediately", "Get the object back immediately after placing it into the cloner. If set, the mod will ignore the 'On Change' property.", () => DataLoader.ModConfig.GetObjectBackImmediately, (bool val) => DataLoader.ModConfig.GetObjectBackImmediately = val);
-
             }
 
         }

--- a/CustomCrystalariumMod/ModConfig.cs
+++ b/CustomCrystalariumMod/ModConfig.cs
@@ -6,6 +6,8 @@
         public bool GetObjectBackOnChange;
         public bool GetObjectBackImmediately;
         public bool BlockChange;
+        public bool EnableCrystalariumCloneEveryObject;
+        public int DefaultCloningTime = 5000;
         public bool OverrideContentPackGetObjectProperties;
     }
 }

--- a/CustomCrystalariumMod/ObjectOverrides.cs
+++ b/CustomCrystalariumMod/ObjectOverrides.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Netcode;
 using StardewValley;
+using StardewValley.Tools;
 
 namespace CustomCrystalariumMod
 {
@@ -58,6 +59,10 @@ namespace CustomCrystalariumMod
                                 else if ((object1.Category == -2 || object1.Category == -12) && object1.ParentSheetIndex != 74)
                                 {
                                     minutesUntilReady = DataLoader.Helper.Reflection.GetMethod(__instance, "getMinutesForCrystalarium").Invoke<int>(object1.ParentSheetIndex);
+                                }
+                                else if (DataLoader.ModConfig.EnableCrystalariumCloneEveryObject)
+                                {
+                                    minutesUntilReady = DataLoader.ModConfig.DefaultCloningTime;
                                 }
                                 else
                                 {
@@ -119,25 +124,37 @@ namespace CustomCrystalariumMod
             return true;
         }
 
-        public static bool PerformRemoveAction(ref Object __instance, ref Vector2 tileLocation)
+        public static bool PerformRemoveAction(ref Object __instance, ref Vector2 tileLocation, GameLocation environment)
         {
-            if (__instance.Name == "Crystalarium")
+            if (ClonerController.GetCloner(__instance.Name) is CustomCloner cloner)
             {
-                if (DataLoader.ModConfig.GetObjectBackOnChange && !DataLoader.ModConfig.GetObjectBackImmediately)
+                if (__instance.heldObject.Value != null)
                 {
-                    if (__instance.heldObject.Value != null)
+                    if (DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? !DataLoader.ModConfig.GetObjectBackImmediately : !cloner.GetObjectBackImmediately)
                     {
-                        Game1.createItemDebris(__instance.heldObject.Value.getOne(), tileLocation * 64f, (Game1.player.FacingDirection + 2) % 4, (GameLocation)null, -1);
+                        environment.debris.Add(new Debris((Object) __instance.heldObject.Value, __instance.TileLocation * 64f + new Vector2(32f, 32f)));
                     }
+
+                    __instance.heldObject.Value = null;
                 }
             }
-            else if (ClonerController.GetCloner(__instance.Name) is CustomCloner cloner)
+            return true;
+        }
+
+        public static bool PerformToolAction(ref Object __instance, Tool t, GameLocation location)
+        {
+            if (__instance.isTemporarilyInvisible)
             {
-                if (DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.GetObjectBackOnChange && !DataLoader.ModConfig.GetObjectBackImmediately : cloner.GetObjectBackOnChange && !cloner.GetObjectBackImmediately)
+                return true;
+            }
+
+            if (__instance.Type != null && __instance.Type.Equals("Crafting") && !(t is MeleeWeapon) && t.isHeavyHitter())
+            {
+                if ((bool)__instance.bigCraftable.Value && __instance.ParentSheetIndex == 21 && __instance.heldObject.Value != null)
                 {
-                    if (__instance.heldObject.Value != null)
+                    if (DataLoader.ModConfig.GetObjectBackImmediately && !__instance.readyForHarvest.Value)
                     {
-                        Game1.createItemDebris(__instance.heldObject.Value.getOne(), tileLocation * 64f, (Game1.player.FacingDirection + 2) % 4, (GameLocation)null, -1);
+                        __instance.heldObject.Value = null;
                     }
                 }
             }

--- a/CustomCrystalariumMod/contentPackTemplate/ClonersData.json
+++ b/CustomCrystalariumMod/contentPackTemplate/ClonersData.json
@@ -1,6 +1,8 @@
 ﻿[
     {
         "Name": "Grave Stone", //Name of the cloner. Required.
+        "EnableCloneEveryObject": false, //If true, the cloner will be able to clone every object. Default is false.
+        "DefaultCloningTime": 5000, //Cloning time use for undefined objects when enable clone every object is true. Default is 5000.
         "GetObjectBackOnChange": true, //If true, you'll get the item you placed before back from the cloner when you place a new item or remove the cloner from the ground. Default is false.
         "GetObjectBackImmediately": false, //If true, the cloner will let you get the item you placed back immediately. Also, the ﻿GetObjectBackOnChange option will be ignored. Default is false.
         "BlockChange": false, //If true, you won't be able to change the object inside. You will need to remove the cloner from the ground. Default is false. 

--- a/CustomCrystalariumMod/i18n/hu.json
+++ b/CustomCrystalariumMod/i18n/hu.json
@@ -1,0 +1,5 @@
+﻿{
+    "CustomCrystalarium.Letter": "@ gazda,^^   Feloldottuk a prizmás szilánkok elhelyezésének tilalmát a kristályáriumban. A legújabb tanulmányok kimutatták, hogy biztonságos és jól működik.^   Kezdetben úgy gondoltuk, hogy a szilánkból származó EMF negatív kölcsönhatásba lép a kristályáriummal, és káros lehet a közelben lévő emberekre. De ez nem így van, csak sokkal több időt vesz igénybe a szilánkok klónozása.^   Örömmel jelentjük be azt is, hogy 'külső segítséggel' a kristályáriumot úgy is beállíthatod, hogy ne csak drágaköveket és ásványokat, hanem különféle elemeket is másoljon. Még az ásványok és a drágakövek aktuális másolási idejét is meg lehet változtatni.^^   -A Ferngill-i Technológiai Társaság",
+    "CustomCrystalarium.Letter.Title": "Prizmás szilánkok a kristályáriumban",
+    "CustomCrystalarium.Dialogue.BlockChange": "Nem lehet megváltoztatni az elemet."
+}

--- a/CustomCrystalariumMod/integrations/ApiLetter.cs
+++ b/CustomCrystalariumMod/integrations/ApiLetter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace CustomCrystalariumMod.integrations
+{
+    public class ApiLetter : ILetter
+    {
+        /// <summary>
+        /// this letter unique id
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// text to be show on the letter menu. You can use @ to put the players name and ^ for line breaks. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// this letter group id. Letter with the same group id are never delivered in the same day.
+        /// Letters registered first have priority, unless they have the suffix ".Random", in that case a random letter will be chosen.
+        /// </summary>
+        public string GroupId { get; set; }
+
+        /// <summary>
+        /// this letter title to be show in the collections menu. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// list of static items to be added in the letter. If null or empty, no item is added
+        /// There is a bug with the game when adding more than one object. It draws one over the other, and when clicked the one showing is the last one to be picked.
+        /// </summary>
+        public List<Item> Items { get; set; }
+
+        /// <summary>
+        /// name of the recipe to be learned with the letter
+        /// </summary>
+        public string Recipe { get; set; }
+
+        /// <summary>
+        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
+        /// </summary>
+        public int WhichBG { get; set; }
+
+        /// <summary>
+        /// custom texture to replace the game default. must follow the same proportions and image structure
+        /// </summary>
+        public Texture2D LetterTexture { get; set; }
+
+        /// <summary>
+        /// number of the text color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
+        /// </summary>
+        public int? TextColor { get; set; }
+
+        /// <summary>
+        /// custom texture to replace the game default close button. must follow the same proportions
+        /// </summary>
+        public Texture2D UpperRightCloseButtonTexture { get; set; }
+
+        /// <summary>
+        /// when conditions are met any recipe will be learned and the callback will be called. the letter won't show in the mailbox
+        /// </summary>
+        public bool AutoOpen { get; set; }
+
+        /// <summary>
+        /// translation helper of the content pack or mod
+        /// </summary>
+        public ITranslationHelper I18N { get; set; }
+    }
+}

--- a/CustomCrystalariumMod/integrations/GenericModConfigMenuApi.cs
+++ b/CustomCrystalariumMod/integrations/GenericModConfigMenuApi.cs
@@ -8,5 +8,6 @@ namespace CustomCrystalariumMod.integrations
         void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
         void RegisterLabel(IManifest mod, string labelName, string labelDesc);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
     }
 }

--- a/CustomCrystalariumMod/integrations/ILetter.cs
+++ b/CustomCrystalariumMod/integrations/ILetter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace CustomCrystalariumMod.integrations
+{
+    public interface ILetter
+    {
+        /// <summary>
+        /// this letter unique id
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// text to be show on the letter menu. You can use @ to put the players name and ^ for line breaks. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        string Text { get; }
+
+        /// <summary>
+        /// this letter group id. Letter with the same group id are never delivered in the same day.
+        /// Letters registered first have priority, unless they have the suffix ".Random", in that case a random letter will be chosen.
+        /// </summary>
+        string GroupId { get; }
+        /// <summary>
+        /// this letter title to be show in the collections menu. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        string Title { get; }
+
+        /// <summary>
+        /// list of static items to be added in the letter. If null or empty, no item is added
+        /// There is a bug with the game when adding more than one object. It draws one over the other, and when clicked the one showing is the last one to be picked.
+        /// </summary>
+        List<Item> Items { get; }
+
+        /// <summary>
+        /// name of the recipe to be learned with the letter
+        /// </summary>
+        string Recipe { get; }
+
+        /// <summary>
+        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
+        /// </summary>
+        int WhichBG { get; }
+
+        /// <summary>
+        /// custom texture to replace the game default. must follow the same proportions and image structure
+        /// </summary>
+        public Texture2D LetterTexture { get; }
+
+        /// <summary>
+        /// number of the text color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
+        /// </summary>
+        public int? TextColor { get; }
+
+        /// <summary>
+        /// custom texture to replace the game default close button. must follow the same proportions
+        /// </summary>
+        public Texture2D UpperRightCloseButtonTexture { get; }
+
+        /// <summary>
+        /// when conditions are met any recipe will be learned and the callback will be called. the letter won't show in the mailbox
+        /// </summary>
+        public bool AutoOpen { get; }
+
+        /// <summary>
+        /// translation helper of the content pack or mod
+        /// </summary>
+        public ITranslationHelper I18N { get; }
+    }
+}

--- a/CustomCrystalariumMod/integrations/IMailFrameworkModApi.cs
+++ b/CustomCrystalariumMod/integrations/IMailFrameworkModApi.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace CustomCrystalariumMod.integrations
+{
+    public interface IMailFrameworkModApi
+    {
+        public void RegisterLetter(ILetter iLetter, Func<ILetter, bool> condition, Action<ILetter> callback = null, Func<ILetter, List<Item>> dynamicItems = null);
+    }
+}

--- a/CustomCrystalariumMod/manifest.json
+++ b/CustomCrystalariumMod/manifest.json
@@ -1,16 +1,17 @@
 ﻿{
-  "Name": "Custom Crystalarium Mod",
-  "Author": "Digus",
-  "Version": "1.3.0",
-  "Description": "Adds a way to customize the crystalarium machine. Adds a way to create custom cloners using content packs.",
-  "UniqueID": "DIGUS.CustomCrystalariumMod",
-  "EntryDll": "CustomCrystalariumMod.dll",
-  "MinimumApiVersion": "3.18.0",
-  "Dependencies": [
-	  {
-		  "UniqueID": "DIGUS.MailFrameworkMod",
-		  "MinimumVersion": "1.13.0"
-	  }
-  ],
-  "UpdateKeys": [ "Nexus:2516" ]
+    "Name": "Custom Crystalarium Mod",
+    "Author": "Digus",
+    "Version": "1.4.0",
+    "Description": "Adds a way to customize the crystalarium machine. Adds a way to create custom cloners using content packs.",
+    "UniqueID": "DIGUS.CustomCrystalariumMod",
+    "EntryDll": "CustomCrystalariumMod.dll",
+    "MinimumApiVersion": "3.18.0",
+    "Dependencies": [
+        {
+            "UniqueID": "DIGUS.MailFrameworkMod",
+            "MinimumVersion": "1.15.0",
+            "IsRequired": false
+        }
+    ],
+    "UpdateKeys": [ "Nexus:2516" ]
 }


### PR DESCRIPTION
- Removing MFM dependency
- Adding letter using MFM API.
- New property to enable to crystalarium or cloner to clone every object.
- New property to set the deafult time to clone for undefined object.
- Adds new properties to Config Menu.
- Fix to situations where you could get a cloner or a crystalarium to duplicate items with no wait time by removing it from the ground.
- Change way to create Debris, so it use the same method as the game.
- Hungarian translation.