### PR TITLE
Mail Services Mod 1.5.2

### DIFF
--- a/MailServicesMod/ToolUpgradeOverrides.cs
+++ b/MailServicesMod/ToolUpgradeOverrides.cs
@@ -36,7 +36,7 @@ namespace MailServicesMod
         {
             try
             {
-                itemsToAdd.RemoveAll(i => i is GenericTool);
+                itemsToAdd.RemoveAll(i => i is GenericTool g && g.ItemId.EndsWith("TrashCan"));
                 if (itemsToAdd.Count == 0)
                 {
                     itemsToAdd = null;

--- a/MailServicesMod/manifest.json
+++ b/MailServicesMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "Mail Services Mod",
     "Author": "Digus",
-    "Version": "1.5.1",
+    "Version": "1.5.2",
     "Description": "Mail services to send and receive item using the mailbox.",
     "UniqueID": "Digus.MailServicesMod",
     "EntryDll": "MailServicesMod.dll",


### PR DESCRIPTION
- Only remove the tool from being added to the inventory if it's the trash can. It caused conflict with Animal Husbandry custom tools.