### PR TITLE
Animal Husbandry Mod 2.6.8

### DIFF
--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -297,7 +297,6 @@ namespace AnimalHusbandryMod
 
                 harmony.Patch(
                     original: AccessTools.Method(typeof(FarmAnimal), nameof(FarmAnimal.dayUpdate)),
-                    postfix: new HarmonyMethod(typeof(FarmAnimalOverrides), nameof(FarmAnimalOverrides.dayUpdate)),
                     transpiler: new HarmonyMethod(typeof(FarmAnimalOverrides), nameof(FarmAnimalOverrides.dayUpdate_Transpiler))
                 );
 

--- a/ButcherMod/animals/AnimalQueryMenuExtended.cs
+++ b/ButcherMod/animals/AnimalQueryMenuExtended.cs
@@ -204,7 +204,7 @@ namespace AnimalHusbandryMod.animals
                 return;
             if (_movingAnimal.GetValue())
             {
-                Building buildingAt = (Game1.getLocationFromName("Farm") as Farm).getBuildingAt(new Vector2((float)((x + Game1.viewport.X) / Game1.tileSize), (float)((y + Game1.viewport.Y) / Game1.tileSize)));
+                Building buildingAt = Game1.getFarm().getBuildingAt(new Vector2((float)((Game1.getOldMouseX(ui_scale: false) + Game1.viewport.X) / Game1.tileSize), (float)((Game1.getOldMouseY(ui_scale: false) + Game1.viewport.Y) / Game1.tileSize)));
                 if 
                 (
                     buildingAt != null                     
@@ -228,7 +228,7 @@ namespace AnimalHusbandryMod.animals
             {
                 if (this.yesButton.containsPoint(x, y))
                 {
-                    (this._farmAnimal.home.indoors.Value as AnimalHouse)?.animalsThatLiveHere.Remove(this._farmAnimal.myID.Value);
+                    (this._farmAnimal.home.GetIndoors() as AnimalHouse)?.animalsThatLiveHere.Remove(this._farmAnimal.myID.Value);
                     this._farmAnimal.health.Value = -1;
                     int num1 = this._farmAnimal.Sprite.SourceRect.Width / 2;
                     for (int index = 0; index < num1; ++index)
@@ -305,8 +305,8 @@ namespace AnimalHusbandryMod.animals
             base.performHoverAction(x, y);
             if (_movingAnimal.GetValue())
             {
-                Vector2 tile = new Vector2((float)((x + Game1.viewport.X) / Game1.tileSize), (float)((y + Game1.viewport.Y) / Game1.tileSize));
-                Farm locationFromName = Game1.getLocationFromName("Farm") as Farm;
+                Vector2 tile = new Vector2((float)((Game1.getOldMouseX(ui_scale: false) + Game1.viewport.X) / Game1.tileSize), (float)((Game1.getOldMouseY(ui_scale: false) + Game1.viewport.Y) / Game1.tileSize));
+                Farm locationFromName = Game1.getFarm();
                 Building buildingAt = locationFromName.getBuildingAt(tile);
                 if (buildingAt != null 
                     && buildingAt.color.Equals(Color.LightGreen * 0.8f)
@@ -405,7 +405,10 @@ namespace AnimalHusbandryMod.animals
 
             if (!movingAnimal && !Game1.globalFade)
             {
-                b.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.75f);
+                if (!Game1.options.showClearBackgrounds)
+                {
+                    b.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.75f);
+                }
                 Game1.drawDialogueBox(base.xPositionOnScreen, base.yPositionOnScreen + 128, AnimalQueryMenu.width, AnimalQueryMenu.height - 128, speaker: false, drawOnlyBox: true);
                 this._textBox.Draw(b);
                 int age = (this._farmAnimal.GetDaysOwned() + 1) / 28 + 1;
@@ -415,24 +418,28 @@ namespace AnimalHusbandryMod.animals
                     ageText += Game1.content.LoadString("Strings\\UI:AnimalQuery_AgeBaby");
                 }
                 Utility.drawTextWithShadow(b, ageText, Game1.smallFont, new Vector2(base.xPositionOnScreen + IClickableMenu.spaceToClearSideBorder + 32, base.yPositionOnScreen + IClickableMenu.spaceToClearTopBorder + 16 + 128), Game1.textColor);
-                int num2 = 0;
+                int yOffset = 0;
                 if (this._parentName != null)
                 {
-                    num2 = Game1.tileSize / 3;
+                    yOffset = Game1.tileSize / 3;
                     Utility.drawTextWithShadow(b, Game1.content.LoadString("Strings\\UI:AnimalQuery_Parent", (object)this._parentName), Game1.smallFont, new Vector2((float)(this.xPositionOnScreen + IClickableMenu.spaceToClearSideBorder + Game1.tileSize / 2), (float)(Game1.tileSize / 2 + this.yPositionOnScreen + IClickableMenu.spaceToClearTopBorder + Game1.tileSize / 4 + Game1.tileSize * 2)), Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
                 }
-                int num3 = loveLevel * 1000.0 % 200.0 >= 100.0 ? (int)(loveLevel * 1000.0 / 200.0) : -100;
+                int halfHeart = loveLevel * 1000.0 % 200.0 >= 100.0 ? (int)(loveLevel * 1000.0 / 200.0) : -100;
                 for (int index = 0; index < 5; ++index)
                 {
-                    b.Draw(Game1.mouseCursors, new Vector2((float)(this.xPositionOnScreen + Game1.tileSize * 3 / 2 + 8 * Game1.pixelZoom * index), (float)(num2 + this.yPositionOnScreen - Game1.tileSize / 2 + Game1.tileSize * 5)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(211 + (loveLevel * 1000.0 <= (double)((index + 1) * 195) ? 7 : 0), 428, 7, 6)), Color.White, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, 0.89f);
-                    if (num3 == index)
-                        b.Draw(Game1.mouseCursors, new Vector2((float)(this.xPositionOnScreen + Game1.tileSize * 3 / 2 + 8 * Game1.pixelZoom * index), (float)(num2 + this.yPositionOnScreen - Game1.tileSize / 2 + Game1.tileSize * 5)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(211, 428, 4, 6)), Color.White, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, 0.891f);
+                    b.Draw(Game1.mouseCursors, new Vector2((float)(this.xPositionOnScreen + Game1.tileSize * 3 / 2 + 8 * Game1.pixelZoom * index), (float)(yOffset + this.yPositionOnScreen - Game1.tileSize / 2 + Game1.tileSize * 5)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(211 + (loveLevel * 1000.0 <= (double)((index + 1) * 195) ? 7 : 0), 428, 7, 6)), Color.White, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, 0.89f);
+                    if (halfHeart == index)
+                        b.Draw(Game1.mouseCursors, new Vector2((float)(this.xPositionOnScreen + Game1.tileSize * 3 / 2 + 8 * Game1.pixelZoom * index), (float)(yOffset + this.yPositionOnScreen - Game1.tileSize / 2 + Game1.tileSize * 5)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(211, 428, 4, 6)), Color.White, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, 0.891f);
                 }
-                Utility.drawTextWithShadow(b, Game1.parseText(this._farmAnimal.getMoodMessage(), Game1.smallFont, AnimalQueryMenu.width - IClickableMenu.spaceToClearSideBorder * 2 - Game1.tileSize), Game1.smallFont, new Vector2((float)(this.xPositionOnScreen + IClickableMenu.spaceToClearSideBorder + Game1.tileSize / 2), (float)(num2 + this.yPositionOnScreen + Game1.tileSize * 6 - Game1.tileSize + Game1.pixelZoom)), Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
+                Utility.drawTextWithShadow(b, Game1.parseText(this._farmAnimal.getMoodMessage(), Game1.smallFont, AnimalQueryMenu.width - IClickableMenu.spaceToClearSideBorder * 2 - Game1.tileSize), Game1.smallFont, new Vector2((float)(this.xPositionOnScreen + IClickableMenu.spaceToClearSideBorder + Game1.tileSize / 2), (float)(yOffset + this.yPositionOnScreen + Game1.tileSize * 6 - Game1.tileSize + Game1.pixelZoom)), Game1.textColor, 1f, -1f, -1, -1, 1f, 3);
                 this.okButton.draw(b);
                 this.sellButton.draw(b);
                 this.moveHomeButton.draw(b);
                 allowReproductionButton?.draw(b);
+                if (this._farmAnimal != null && this._farmAnimal.hasEatenAnimalCracker.Value && Game1.objectSpriteSheet_2 != null)
+                {
+                    Utility.drawWithShadow(b, Game1.objectSpriteSheet_2, new Vector2((float)(base.xPositionOnScreen + AnimalQueryMenu.width) - 105.6f, (float)base.yPositionOnScreen + 224f), new Microsoft.Xna.Framework.Rectangle(16, 240, 16, 16), Color.White, 0f, Vector2.Zero, 4f, flipped: false, 0.89f);
+                }
                 // START pregnancyStatus treatStatus meatButton
                 animalContestIndicator?.draw(b);
                 pregnantStatus?.draw(b);
@@ -442,10 +449,13 @@ namespace AnimalHusbandryMod.animals
                 // ADDED || confirmingMeat
                 if (confirmingSell || confirmingMeat)
                 {
-                    b.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.75f);
+                    if (!Game1.options.showClearBackgrounds)
+                    {
+                        b.Draw(Game1.fadeToBlackRect, Game1.graphics.GraphicsDevice.Viewport.Bounds, Color.Black * 0.75f);
+                    }
                     Game1.drawDialogueBox(Game1.viewport.Width / 2 - Game1.tileSize * 5 / 2, Game1.viewport.Height / 2 - Game1.tileSize * 3, Game1.tileSize * 5, Game1.tileSize * 4, false, true, (string)null, false);
-                    string text2 = Game1.content.LoadString("Strings\\UI:AnimalQuery_ConfirmSell");
-                    b.DrawString(Game1.dialogueFont, text2, new Vector2((float)(Game1.viewport.Width / 2) - Game1.dialogueFont.MeasureString(text2).X / 2f, (float)(Game1.viewport.Height / 2 - Game1.tileSize * 3 / 2 + 8)), Game1.textColor);
+                    string confirmText = Game1.content.LoadString("Strings\\UI:AnimalQuery_ConfirmSell");
+                    b.DrawString(Game1.dialogueFont, confirmText, new Vector2((float)(Game1.viewport.Width / 2) - Game1.dialogueFont.MeasureString(confirmText).X / 2f, (float)(Game1.viewport.Height / 2 - Game1.tileSize * 3 / 2 + 8)), Game1.textColor);
                     this.yesButton.draw(b);
                     this.noButton.draw(b);
                 }
@@ -460,50 +470,44 @@ namespace AnimalHusbandryMod.animals
             }
             else if (!Game1.globalFade)
             {
-                string text = Game1.content.LoadString("Strings\\UI:AnimalQuery_ChooseBuilding", (object)this._farmAnimal.displayHouse, (object)this._farmAnimal.displayType);
-                Game1.drawDialogueBox(Game1.tileSize / 2, -Game1.tileSize, (int)Game1.dialogueFont.MeasureString(text).X + IClickableMenu.borderWidth * 2 + Game1.tileSize / 4, Game1.tileSize * 2 + IClickableMenu.borderWidth * 2, false, true, (string)null, false);
+                string text = Game1.content.LoadString("Strings\\UI:AnimalQuery_ChooseBuilding", this._farmAnimal.displayHouse, this._farmAnimal.displayType);
+                Game1.drawDialogueBox(Game1.tileSize / 2, -Game1.tileSize, (int)Game1.dialogueFont.MeasureString(text).X + IClickableMenu.borderWidth * 2 + Game1.tileSize / 4, Game1.tileSize * 2 + IClickableMenu.borderWidth * 2, speaker: false, drawOnlyBox: true);
                 b.DrawString(Game1.dialogueFont, text, new Vector2((float)(Game1.tileSize / 2 + IClickableMenu.spaceToClearSideBorder * 2 + 8), (float)(Game1.tileSize / 2 + Game1.pixelZoom * 3)), Game1.textColor);
                 this.okButton.draw(b);
             }
             this.drawMouse(b);
         }
 
-        public static bool Pet(FarmAnimal __instance, ref Farmer who)
+        public static bool Pet(FarmAnimal __instance, ref Farmer who, bool is_auto_pet)
         {
-            if (!who.FarmerSprite.PauseForSingleAnimation
-                && !(Game1.timeOfDay >= 1900 && !__instance.isMoving()))
+            if (who.FarmerSprite.PauseForSingleAnimation) return true;
+            if (is_auto_pet) return true;
+            if (Game1.timeOfDay >= 1900 && !__instance.isMoving()) return true;
+            if (!__instance.wasPet.Value) return true;
+            if (who.ActiveObject is { QualifiedItemId: "(O)178" }) return true;
+            if (!__instance.hasEatenAnimalCracker.Value && who is { ActiveObject.QualifiedItemId: "(O)GoldenAnimalCracker" }) return true;
+            who.Halt();
+            who.faceGeneralDirection(__instance.Position, 0, opposite: false, useTileCalculations: false);
+            __instance.Halt();
+            __instance.Sprite.StopAnimation();
+            __instance.uniqueFrameAccumulator = -1;
+            switch (Game1.player.FacingDirection)
             {
-                if(__instance.wasPet.Value
-                        &&(
-                            who.ActiveObject == null 
-                            || who.ActiveObject.ParentSheetIndex != 178)
-                        )
-                {
-                    who.Halt();
-                    who.faceGeneralDirection(__instance.Position, 0, false);
-                    __instance.Halt();
-                    __instance.Sprite.StopAnimation();
-                    __instance.uniqueFrameAccumulator = -1;
-                    switch (Game1.player.FacingDirection)
-                    {
-                        case 0:
-                            __instance.Sprite.currentFrame = 0;
-                            break;
-                        case 1:
-                            __instance.Sprite.currentFrame = 12;
-                            break;
-                        case 2:
-                            __instance.Sprite.currentFrame = 8;
-                            break;
-                        case 3:
-                            __instance.Sprite.currentFrame = 4;
-                            break;
-                    }
-                    Game1.activeClickableMenu = (IClickableMenu)new AnimalQueryMenuExtended(__instance);
-                    return false;
-                }
+                case 0:
+                    __instance.Sprite.currentFrame = 0;
+                    break;
+                case 1:
+                    __instance.Sprite.currentFrame = 12;
+                    break;
+                case 2:
+                    __instance.Sprite.currentFrame = 8;
+                    break;
+                case 3:
+                    __instance.Sprite.currentFrame = 4;
+                    break;
             }
-            return true;
+            Game1.activeClickableMenu = (IClickableMenu)new AnimalQueryMenuExtended(__instance);
+            return false;
         }
     }
 }

--- a/ButcherMod/manifest.json
+++ b/ButcherMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Animal Husbandry Mod",
    "Author": "Digus",
-   "Version": "2.6.7",
+   "Version": "2.6.8",
    "Description": "Adds features related to animal husbandry.",
    "UniqueID": "DIGUS.ANIMALHUSBANDRYMOD",
    "EntryDll": "AnimalHusbandryMod.dll",

--- a/ButcherMod/tools/FeedingBasketOverrides.cs
+++ b/ButcherMod/tools/FeedingBasketOverrides.cs
@@ -73,8 +73,6 @@ namespace AnimalHusbandryMod.tools
             x = (int)who.GetToolLocation(false).X;
             y = (int)who.GetToolLocation(false).Y;
             Rectangle rectangle = new Rectangle(x - Game1.tileSize / 2, y - Game1.tileSize / 2, Game1.tileSize, Game1.tileSize);
-            //// Added this because for some wierd reason the current value appears subtracted by 5 the first time the tool is used.
-            //__instance.CurrentParentTileIndex = InitialParentTileIndex;
 
             if (!DataLoader.ModConfig.DisableTreats)
             {
@@ -524,16 +522,16 @@ namespace AnimalHusbandryMod.tools
 
         public static bool drawTool(Farmer f, int currentToolIndex)
         {
-            Tool correntTool = f.CurrentTool;
-            if (!IsFeedingBasket(correntTool)) return true;
-            correntTool.draw(Game1.spriteBatch);
+            Tool currentTool = f.CurrentTool;
+            if (!IsFeedingBasket(currentTool)) return true;
+            currentTool.draw(Game1.spriteBatch);
             return false;
         }
 
         public static bool endUsing(GameLocation location, Farmer who)
         {
-            Tool correntTool = who.CurrentTool;
-            if (!IsFeedingBasket(correntTool)) return true;
+            Tool currentTool = who.CurrentTool;
+            if (!IsFeedingBasket(currentTool)) return true;
 
             who.stopJittering();
             who.canReleaseTool = false;
@@ -547,7 +545,7 @@ namespace AnimalHusbandryMod.tools
 
         private static bool IsFeedingBasket(Item tool)
         {
-            return tool.modData.ContainsKey(FeedingBasketKey);
+            return tool?.modData?.ContainsKey(FeedingBasketKey) ?? false;
         }
     }
 }

--- a/ButcherMod/tools/InseminationSyringeOverrides.cs
+++ b/ButcherMod/tools/InseminationSyringeOverrides.cs
@@ -319,7 +319,7 @@ namespace AnimalHusbandryMod.tools
 
         private static bool IsInseminationSyringe(Item tool)
         {
-            return tool.modData.ContainsKey(InseminationSyringeKey);
+            return tool?.modData?.ContainsKey(InseminationSyringeKey) ?? false;
         }
 
         private static bool CheckCorrectProduct(FarmAnimal animal, SObject o)

--- a/ButcherMod/tools/MeatCleaverOverrides.cs
+++ b/ButcherMod/tools/MeatCleaverOverrides.cs
@@ -257,7 +257,7 @@ namespace AnimalHusbandryMod.tools
 
         private static bool IsMeatCleaver(Item tool)
         {
-            return tool.modData.ContainsKey(MeatCleaverKey);
+            return tool?.modData?.ContainsKey(MeatCleaverKey) ?? false;
         }
     }
 }

--- a/ButcherMod/tools/ParticipantRibbonOverrides.cs
+++ b/ButcherMod/tools/ParticipantRibbonOverrides.cs
@@ -282,7 +282,7 @@ namespace AnimalHusbandryMod.tools
 
         private static bool IsParticipantRibbon(Item tool)
         {
-            return tool.modData.ContainsKey(ParticipantRibbonKey);
+            return tool?.modData?.ContainsKey(ParticipantRibbonKey) ?? false;
         }
 
     }


### PR DESCRIPTION
- Fix to animal query menu extended not showing the cracker icon when the animal had eaten it.
- Fix to animal query menu extended not respecting showClearBackground option.
- Fix to animals not accepting the cracker after they were pet.
- Some refactoring to Animal Query Menu Extended code
- Fix to producer bonus not being applied
- New transpiler to fix fertility bonus not being applied to layed products.
- Removing old postfix logic that was not working.
- Making the tool validation null safe to avoid bug with other tools. (Afected the StrenghtGame in the stardew valley fair)