### PR TITLE
Producer Framework Mod 1.9.0

### DIFF
--- a/ProducerFrameworkMod/ContentPack/ProducerConfig.cs
+++ b/ProducerFrameworkMod/ContentPack/ProducerConfig.cs
@@ -12,6 +12,7 @@ namespace ProducerFrameworkMod.ContentPack
         public bool AlternateFrameProducing;
         public bool AlternateFrameWhenReady;
         public bool DisableBouncingAnimationWhileWorking;
+        public bool AllowFairyDust = true;
         public NoInputStartMode? NoInputStartMode;
         public Dictionary<StardewStats, string> IncrementStatsOnOutput;
         public Dictionary<string, string> IncrementStatsLabelOnOutput;

--- a/ProducerFrameworkMod/ContentPackTemplate/ProducersConfig.json
+++ b/ProducerFrameworkMod/ContentPackTemplate/ProducersConfig.json
@@ -7,6 +7,7 @@
 		"AlternateFrameProducing": true, //If the producer should use the alternate frame when producing.
 		"AlternateFrameWhenReady": true, //If the producer should use the alternate frame and ready for harvest.
 		"DisableBouncingAnimationWhileWorking": false, // If the producer bouncing animation while working should be disabled.
+		"AllowFairyDust": false, // If the producer should allow fairy dust use to speed up the producer. Default is true. Will work even if no producer configuration is defined. To disable fairy dust you need a producer config setting this property to false. This is to keep legacy behavior.
 		"NoInputStartMode": "Placement", // [Placement|DayUpdate] //If the machine has a value for this property, it can only have one ProducerRule without a InputIdentifier. If Placement, the machine will start on placement, and will restart every time the produced object is taken out. If DayUpdate, the machine will start at the begin of the day. Default is null.
 		"IncrementStatsOnOutput": { //Pairs of "stats:object" that identify what should be incremented.
 			"GoatCheeseMade": "Goat Cheese", //First value is the stats to be incremented, second value is which output should be produced for the stat to be incremented. The identifier can be the index, name, category or context tag of the output. Will increment the stats by the amount of the stack.

--- a/ProducerFrameworkMod/Controllers/ProducerController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerController.cs
@@ -45,6 +45,8 @@ namespace ProducerFrameworkMod.Controllers
             }
         };
 
+        private const string WarningNotBugPrefix = "This is just a Warning, don't report this as a bug. ";
+
         /// <summary>
         /// Adds or replace a custom producer rule to the game.
         /// You should probably call this method everytime a save game loads, to ensure all custom objects are properly loaded.
@@ -82,11 +84,11 @@ namespace ProducerFrameworkMod.Controllers
                     }
                     else if (string.IsNullOrEmpty(producerRule.InputIdentifier) && (GetProducerConfig(producerRule.ProducerQualifiedItemId)?.NoInputStartMode == null))
                     {
-                        ProducerFrameworkModEntry.ModMonitor.Log($"The InputIdentifier property can't be null or empty if there is no config for 'NoInputStartMode' for producer '{producerRule.ProducerIdentification}'. This rule will be ignored.", LogLevel.Warn);
+                        ProducerFrameworkModEntry.ModMonitor.Log($"The InputIdentifier property can't be null or empty if there is no config for 'NoInputStartMode' for producer '{producerRule.ProducerIdentification}'. This rule will be ignored.", producerRule.WarningsLogLevel);
                     }
                     else if ((!string.IsNullOrEmpty(producerRule.InputIdentifier) && GetProducerConfig(producerRule.ProducerQualifiedItemId)?.NoInputStartMode != null))
                     {
-                        ProducerFrameworkModEntry.ModMonitor.Log($"The InputIdentifier property can't have a value if there is a config for 'NoInputStartMode' for producer '{producerRule.ProducerIdentification}'. This rule will be ignored.", LogLevel.Warn);
+                        ProducerFrameworkModEntry.ModMonitor.Log($"The InputIdentifier property can't have a value if there is a config for 'NoInputStartMode' for producer '{producerRule.ProducerIdentification}'. This rule will be ignored.", producerRule.WarningsLogLevel);
                     } 
                     else
                     {
@@ -129,7 +131,7 @@ namespace ProducerFrameworkMod.Controllers
                             outputConfig.OutputItemId = FindObjectKey(outputConfig.OutputIdentifier, true);
                             if(outputConfig.OutputItemId == null)
                             {
-                                ProducerFrameworkModEntry.ModMonitor.Log($"No Output found for '{outputConfig.OutputIdentifier}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
+                                ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No Output found for '{outputConfig.OutputIdentifier}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
                                 break;
                             }
                             
@@ -138,7 +140,7 @@ namespace ProducerFrameworkMod.Controllers
                                 var fuelItemId = FindObjectKey(fuel.Key);
                                 if (fuelItemId == null)
                                 {
-                                    ProducerFrameworkModEntry.ModMonitor.Log($"No required fuel found for '{fuel.Key}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
+                                    ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No required fuel found for '{fuel.Key}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
                                     outputConfig.OutputItemId = null;
                                     break;
                                 }
@@ -159,7 +161,7 @@ namespace ProducerFrameworkMod.Controllers
                             string fuelItemId = FindObjectKey(fuel.Key);
                             if (fuelItemId == null)
                             {
-                                ProducerFrameworkModEntry.ModMonitor.Log($"No fuel found for '{fuel.Key}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
+                                ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No fuel found for '{fuel.Key}', producer '{producerRule.ProducerIdentification}' and input '{producerRule.InputIdentifier}'. This rule will be ignored.", producerRule.WarningsLogLevel);
                                 break;
                             }
                             producerRule.FuelList.Add(new Tuple<string, int>(fuelItemId, fuel.Value));
@@ -306,7 +308,7 @@ namespace ProducerFrameworkMod.Controllers
                             var outputIndex = FindObjectKey(animation.Key);
                             if (outputIndex == null)
                             {
-                                ProducerFrameworkModEntry.ModMonitor.Log($"No object found for '{animation.Key}', producer '{producerConfig.ProducerIdentification}'. This animation will be ignored.", LogLevel.Debug);
+                                ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No object found for '{animation.Key}', producer '{producerConfig.ProducerIdentification}'. This animation will be ignored.", LogLevel.Debug);
                                 break;
                             }
                             producerConfig.ProducingAnimation.AdditionalAnimationsId[outputIndex] = animation.Value;
@@ -320,7 +322,7 @@ namespace ProducerFrameworkMod.Controllers
                             var outputIndex = FindObjectKey(animation.Key);
                             if (outputIndex == null)
                             {
-                                ProducerFrameworkModEntry.ModMonitor.Log($"No object found for '{animation.Key}', producer '{producerConfig.ProducerIdentification}'. This animation will be ignored.", LogLevel.Debug);
+                                ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No object found for '{animation.Key}', producer '{producerConfig.ProducerIdentification}'. This animation will be ignored.", LogLevel.Debug);
                                 break;
                             }
                             producerConfig.ReadyAnimation.AdditionalAnimationsId[outputIndex] = animation.Value;
@@ -392,7 +394,7 @@ namespace ProducerFrameworkMod.Controllers
                     .FirstOrDefault();
                 if (producer.ProducerQualifiedItemId == null)
                 {
-                    ProducerFrameworkModEntry.ModMonitor.Log($"No producer found for ProducerName {producer.ProducerName}. This rule will be ignored.", LogLevel.Warn);
+                    ProducerFrameworkModEntry.ModMonitor.Log($"{WarningNotBugPrefix}No producer found for ProducerName {producer.ProducerName}. This rule will be ignored.", LogLevel.Warn);
                     return false;
                 }
 
@@ -531,6 +533,16 @@ namespace ProducerFrameworkMod.Controllers
         public static bool HasProducerRuleWithInput(string producerQualifiedItemId)
         {
             return RulesRepository.Keys.Any(k => k.Item1 == producerQualifiedItemId && k.Item2 != null);
+        }
+
+        /// <summary>
+        /// Check if a producer config for a given producer exist.
+        /// </summary>
+        /// <param name="producerQualifiedItemId">The Qualified Item Id of the producer</param>
+        /// <returns>true if there is a config for the producer</returns>
+        public static bool HasProducerConfig(string producerQualifiedItemId)
+        {
+            return ConfigRepository.Keys.Any(k => k == producerQualifiedItemId);
         }
 
         /// <summary>

--- a/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using StardewValley.GameData.Objects;
 using Object = StardewValley.Object;
 using System.Security.AccessControl;
+using StardewValley.Inventories;
 
 namespace ProducerFrameworkMod.Controllers
 {
@@ -65,7 +66,8 @@ namespace ProducerFrameworkMod.Controllers
         {
             foreach (Tuple<string, int> fuel in producerRule.FuelList)
             {
-                if (!(who.getItemCount(fuel.Item1) >= fuel.Item2))
+                IInventory inventory = Object.autoLoadFrom ?? who.Items;
+                if (!(who.getItemCountInList(inventory,fuel.Item1) >= fuel.Item2))
                 {
                     if (!probe)
                     {

--- a/ProducerFrameworkMod/ObjectOverrides.cs
+++ b/ProducerFrameworkMod/ObjectOverrides.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text.RegularExpressions;
+using StardewValley.Inventories;
 using StardewValley.ItemTypeDefinitions;
 using Object = StardewValley.Object;
 #pragma warning disable IDE1006
@@ -21,7 +22,7 @@ namespace ProducerFrameworkMod
     internal class ObjectOverrides
     {
         [HarmonyPriority(Priority.First)]
-        internal static bool PerformObjectDropInAction(Object __instance, Item dropInItem, bool probe, Farmer who, ref bool __result)
+        internal static bool PerformObjectDropInAction(Object __instance, Item dropInItem, bool probe, Farmer who, bool returnFalseIfItemConsumed, ref bool __result)
         {
             if (__instance.isTemporarilyInvisible || dropInItem is not Object input)
                 return false;
@@ -80,7 +81,7 @@ namespace ProducerFrameworkMod
                     ProducerRuleController.ValidateIfAnyFuelStackLessThanRequired(producerRule, who, probe);
 
                     OutputConfig outputConfig = ProducerRuleController.ProduceOutput(producerRule, __instance,
-                        (i, q) => who.getItemCount(i) >= q, who, location, producerConfig, input, probe);
+                        (i, q) => who.getItemCountInList(Object.autoLoadFrom ?? who.Items, i) >= q, who, location, producerConfig, input, probe);
                     if (outputConfig != null)
                     {
                         if (!probe)
@@ -95,8 +96,8 @@ namespace ProducerFrameworkMod
                                 RemoveItemsFromInventory(who, fuel.Item1, fuel.Item2);
                             }
 
-                            input.Stack -= outputConfig.RequiredInputStack ?? producerRule.InputStack;
-                            __result = input.Stack <= 0;
+                            Object.ConsumeInventoryItem(who,input, outputConfig.RequiredInputStack ?? producerRule.InputStack);
+                            __result = !returnFalseIfItemConsumed;
                         }
                         else
                         {
@@ -107,7 +108,7 @@ namespace ProducerFrameworkMod
                 catch (RestrictionException e)
                 {
                     __result = false;
-                    if (e.ShowMessage && e.Message != null && !probe && who.IsLocalPlayer)
+                    if (e.ShowMessage && e.Message != null && !probe && who.IsLocalPlayer && Object.autoLoadFrom == null)
                     {
                         Game1.showRedMessage(e.Message);
                     }
@@ -119,19 +120,20 @@ namespace ProducerFrameworkMod
 
         private static bool RemoveItemsFromInventory(Farmer farmer, string index, int stack)
         {
-            if (farmer.getItemCount(index) >= stack)
+            IInventory inventory = (Object.autoLoadFrom ?? farmer.Items);
+            if (farmer.getItemCountInList(inventory,index) >= stack)
             {
-                for (int index1 = 0; index1 < farmer.Items.Count; ++index1)
+                for (int index1 = 0; index1 < inventory.Count; ++index1)
                 {
-                    if (farmer.Items[index1] != null && farmer.Items[index1] is Object object1 && (object1.QualifiedItemId == index || (int.TryParse(index, out int c) && object1.Category == c)))
+                    if (inventory[index1] != null && inventory[index1] is Object object1 && (object1.QualifiedItemId == index || (int.TryParse(index, out int c) && object1.Category == c)))
                     {
-                        if (farmer.Items[index1].Stack > stack)
+                        if (inventory[index1].Stack > stack)
                         {
-                            farmer.Items[index1].Stack -= stack;
+                            inventory[index1].Stack -= stack;
                             return true;
                         }
-                        stack -= farmer.Items[index1].Stack;
-                        farmer.Items[index1] = (Item)null;
+                        stack -= inventory[index1].Stack;
+                        inventory[index1] = (Item)null;
                     }
                     if (stack <= 0)
                         return true;
@@ -356,7 +358,7 @@ namespace ProducerFrameworkMod
                         {
                             if (ProducerController.GetProducerItem(__instance.QualifiedItemId, null) is { } producerRule)
                             {
-                                ProducerRuleController.ProduceOutput(producerRule, __instance, (i, q) => who.getItemCount(i) >= q, who, who.currentLocation, producerConfig);
+                                ProducerRuleController.ProduceOutput(producerRule, __instance, (i, q) => who.getItemCountInList(Object.autoLoadFrom ?? who.Items, i) >= q, who, who.currentLocation, producerConfig);
                             }
                         }
                         return __result = false;
@@ -463,7 +465,7 @@ namespace ProducerFrameworkMod
                                     try
                                     {
                                         Farmer who = Game1.getFarmer((long)__instance.owner.Value);
-                                        ProducerRuleController.ProduceOutput(producerRule, __instance, (i, q) => who.getItemCount(i) >= q, who, who.currentLocation, producerConfig);
+                                        ProducerRuleController.ProduceOutput(producerRule, __instance, (i, q) => who.getItemCountInList(Object.autoLoadFrom ?? who.Items, i) >= q, who, who.currentLocation, producerConfig);
                                     }
                                     catch (RestrictionException)
                                     {
@@ -545,6 +547,27 @@ namespace ProducerFrameworkMod
                 }
             }
             return true;
+        }
+
+        internal static bool TryApplyFairyDust(Object __instance, bool probe, ref bool __result)
+        {
+            if (__instance.GetMachineData() != null && !ProducerController.HasProducerConfig(__instance.QualifiedItemId)) return true;
+            if (__instance.MinutesUntilReady > 0
+                && ProducerController.GetProducerConfig(__instance.QualifiedItemId) is not { AllowFairyDust: false }
+                && (ProducerController.HasProducerConfig(__instance.QualifiedItemId) || __instance.GetMachineData() is not { AllowFairyDust: false }))
+            {
+                if (!probe)
+                {
+                    Utility.addSprinklesToLocation(__instance.Location, (int)__instance.tileLocation.X,
+                        (int)__instance.tileLocation.Y, 1, 2, 400, 40, Color.White);
+                    Game1.playSound("yoba");
+                    __instance.MinutesUntilReady = 10;
+                    DelayedAction.functionAfterDelay(delegate { __instance.minutesElapsed(10); }, 50);
+                }
+                __result = true;
+            }
+            __result = false;
+            return false;
         }
     }
 }

--- a/ProducerFrameworkMod/ProducerFrameworkModEntry.cs
+++ b/ProducerFrameworkMod/ProducerFrameworkModEntry.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using Microsoft.Xna.Framework.Graphics;
 using ProducerFrameworkMod.Api;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
 using SObject = StardewValley.Object;
 
 namespace ProducerFrameworkMod
@@ -18,13 +19,22 @@ namespace ProducerFrameworkMod
             Helper = helper;
             
             helper.Events.GameLoop.GameLaunched += OnGameLaunched;
-            helper.Events.GameLoop.GameLaunched += DataLoader.LoadContentPacks;
+            helper.Events.GameLoop.UpdateTicking += OnGameLoopOnUpdateTicking ;
             helper.Events.GameLoop.SaveLoaded += DataLoader.LoadContentPacks;
         }
 
+        private void OnGameLoopOnUpdateTicking(object sender, UpdateTickingEventArgs args)
+        {
+            if (args.Ticks == 120)
+            {
+                DataLoader.LoadContentPacks(sender, args);
+                Helper.Events.GameLoop.UpdateTicking -= OnGameLoopOnUpdateTicking;
+            }
+        }
+
         /*********
-        ** Private methods
-        *********/
+         ** Private methods
+         *********/
         /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
@@ -67,6 +77,10 @@ namespace ProducerFrameworkMod
             harmony.Patch(
                 original: AccessTools.Method(typeof(SObject), nameof(SObject.initializeLightSource)),
                 prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.initializeLightSource))
+            );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SObject), nameof(SObject.TryApplyFairyDust)),
+                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.TryApplyFairyDust))
             );
         }
 

--- a/ProducerFrameworkMod/manifest.json
+++ b/ProducerFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "Producer Framework Mod",
     "Author": "Digus",
-    "Version": "1.8.0",
+    "Version": "1.9.0",
     "Description": "Framework to add rules to produce objects or change the vanilla rules.",
     "UniqueID": "Digus.ProducerFrameworkMod",
     "EntryDll": "ProducerFrameworkMod.dll",


### PR DESCRIPTION
- Automate support for vanilla and content patcher machines without needing PFMAutomate
- New property to enable of disable Fairy Dust on machines.
- Support to hoppers
- Fix to Fairy Dust not being applied to PFM machines after SV 1.6
- Fix to avoid loading rules before items.
- Change to some warning messages to user don't report them as bugs.
- PFM now handles removing the item from the inventory after the last stack is consumed. Fix bug were items with 0 stack would be left in the inventory.
- Multiple fixes to fuel consumption.