### PR TITLE
Custom Crystalarium Mod 1.5.0

### DIFF
--- a/CustomCrystalariumMod/ClonerController.cs
+++ b/CustomCrystalariumMod/ClonerController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using StardewValley.Extensions;
 using Object = StardewValley.Object;
 
 namespace CustomCrystalariumMod
@@ -11,37 +12,38 @@ namespace CustomCrystalariumMod
     {
         private static Dictionary<string, CustomCloner> ClonerData =  new Dictionary<string, CustomCloner>();
 
-        public static CustomCloner GetCloner(string name)
+        public static CustomCloner GetCloner(string qualifiedItemId)
         {
-            ClonerData.TryGetValue(name, out CustomCloner result);
+            ClonerData.TryGetValue(qualifiedItemId, out CustomCloner result);
             return result;
         }
 
-        public static bool HasCloner(string name)
+        public static bool HasCloner(string qualifiedItemId)
         {
-            return ClonerData.ContainsKey(name);
+            return ClonerData.ContainsKey(qualifiedItemId);
         }
 
         public static void SetCloner(CustomCloner cloner)
         {
-            ClonerData[cloner.Name] = cloner;
+            ClonerData[cloner.QualifiedItemId] = cloner;
         }
 
         public static int? GetMinutesUntilReady(CustomCloner customCloner, Object clonable)
         {
-            if (customCloner.CloningDataId.ContainsKey(clonable.ParentSheetIndex))
+            int? minutesUntilReady = null;
+            if (customCloner.CloningDataId.TryGetValue(clonable.QualifiedItemId, out var value))
             {
-                return customCloner.CloningDataId[clonable.ParentSheetIndex];
-            }
-            else if (customCloner.CloningDataId.ContainsKey(clonable.Category))
+                minutesUntilReady = value;
+            } 
+            else if (customCloner.CloningDataId.TryGetValue(clonable.Category.ToString(), out value))
             {
-                return customCloner.CloningDataId[clonable.Category];
-            }
-            else if (customCloner.EnableCloneEveryObject)
+                minutesUntilReady = value;
+            } 
+            else if (customCloner.EnableCloneEveryObject && !clonable.HasTypeBigCraftable())
             {
-                return customCloner.DefaultCloningTime;
+                minutesUntilReady = customCloner.DefaultCloningTime;
             }
-            return null;
+            return minutesUntilReady;
         }
     }
 }

--- a/CustomCrystalariumMod/CustomCloner.cs
+++ b/CustomCrystalariumMod/CustomCloner.cs
@@ -9,14 +9,16 @@ namespace CustomCrystalariumMod
     public class CustomCloner
     {
         public string ModUniqueID;
+        public string QualifiedItemId;
         public string Name;
         public bool GetObjectBackOnChange;
         public bool GetObjectBackImmediately;
+        public bool KeepQuality = true;
         public bool BlockChange;
         public bool EnableCloneEveryObject;
         public int DefaultCloningTime = 5000;
         public bool UsePfmForInput;
         public Dictionary<object, int> CloningData;
-        public Dictionary<int, int> CloningDataId = new Dictionary<int, int>();
+        public Dictionary<string, int> CloningDataId = new Dictionary<string, int>();
     }
 }

--- a/CustomCrystalariumMod/CustomCrystalariumMod.csproj
+++ b/CustomCrystalariumMod/CustomCrystalariumMod.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomCrystalariumMod</RootNamespace>
     <AssemblyName>CustomCrystalariumMod</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>

--- a/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
+++ b/CustomCrystalariumMod/CustomCrystalariumModEntry.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Linq;
+using HarmonyLib;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using SObject = StardewValley.Object;
@@ -26,14 +27,25 @@ namespace CustomCrystalariumMod
             Manifest = ModManifest;
 
             helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.UpdateTicking += OnGameLoopOnUpdateTicking;
             helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
 
             helper.ConsoleCommands.Add("config_reload_contentpacks_customcrystalariummod", "Reload all content packs for custom crystalarium mod.", DataLoader.LoadContentPacksCommand);
         }
 
+        private void OnGameLoopOnUpdateTicking(object sender, UpdateTickingEventArgs args)
+        {
+            if (args.Ticks == 120)
+            {
+                DataLoader.LoadCrystalariumDataIds();
+                DataLoader.LoadContentPacksCommand();
+                Helper.Events.GameLoop.UpdateTicking -= OnGameLoopOnUpdateTicking;
+            }
+        }
+
         /*********
-        ** Private methods
-        *********/
+         ** Private methods
+         *********/
         /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
         /// <param name="sender">The event sender.</param>
         /// <param name="e">The event data.</param>
@@ -43,8 +55,8 @@ namespace CustomCrystalariumMod
             var harmony = new Harmony("Digus.CustomCrystalariumMod");
 
             harmony.Patch(
-                original: AccessTools.Method(typeof(SObject), "getMinutesForCrystalarium"),
-                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.GetMinutesForCrystalarium)) { priority = Priority.HigherThanNormal }
+                original: AccessTools.Method(typeof(SObject), "OutputMachine"),
+                postfix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.OutputMachine)) { priority = Priority.HigherThanNormal }
             );
 
             harmony.Patch(
@@ -66,6 +78,11 @@ namespace CustomCrystalariumMod
                 original: AccessTools.Method(typeof(SObject), nameof(SObject.checkForAction)),
                 prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.CheckForAction_prefix)) { priority = Priority.HigherThanNormal },
                 postfix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.CheckForAction_postfix)) { priority = Priority.HigherThanNormal }
+            );
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SObject), nameof(SObject.TryApplyFairyDust)),
+                prefix: new HarmonyMethod(typeof(ObjectOverrides), nameof(ObjectOverrides.TryApplyFairyDust)) { priority = Priority.HigherThanNormal }
             );
         }
 

--- a/CustomCrystalariumMod/DataLoader.cs
+++ b/CustomCrystalariumMod/DataLoader.cs
@@ -8,6 +8,7 @@ using CustomCrystalariumMod.integrations;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
 using StardewValley;
+using StardewValley.GameData.Objects;
 using ModConfig = CustomCrystalariumMod.ModConfig;
 
 namespace CustomCrystalariumMod
@@ -17,11 +18,14 @@ namespace CustomCrystalariumMod
         public static IModHelper Helper;
         public static ITranslationHelper I18N;
         public static ModConfig ModConfig;
-        internal static Dictionary<int,int> CrystalariumDataId = new Dictionary<int, int>();
+        internal static Dictionary<string,int> CrystalariumDataId = new Dictionary<string, int>();
         internal static Dictionary<object,int> CrystalariumData = new Dictionary<object, int>();
+
 
         public const string ClonersDataJson = "ClonersData.json";
         public const string CrystalariumDataJson = "data/CrystalariumData.json";
+        public const string VanillaClonerName = "Crystalarium";
+        public const string VanillaClonerQualifiedItemId = "(BC)21";
         public static Dictionary<object, int> DefaultCystalariumData = new Dictionary<object, int>() { { 74, 20160 } };
 
         public DataLoader(IModHelper helper, IManifest manifest)
@@ -30,17 +34,8 @@ namespace CustomCrystalariumMod
             I18N = helper.Translation;
             ModConfig = helper.ReadConfig<ModConfig>();
 
-            CrystalariumData = Helper.Data.ReadJsonFile<Dictionary<object, int>>(CrystalariumDataJson) ?? DefaultCystalariumData;
-            Helper.Data.WriteJsonFile(CrystalariumDataJson, CrystalariumData);
-
-            Dictionary<int, string> objects = Helper.GameContent.Load<Dictionary<int, string>>(PathUtilities.NormalizeAssetName("Data/ObjectInformation"));
-            CrystalariumData.ToList().ForEach(d =>
-            {
-                int? id = GetId(d.Key, objects);
-                if (id.HasValue && !CrystalariumDataId.ContainsKey(id.Value)) CrystalariumDataId[id.Value] = d.Value;                
-            });
-
-            DataLoader.LoadContentPacksCommand();
+            CrystalariumData = DataLoader.Helper.Data.ReadJsonFile<Dictionary<object, int>>(CrystalariumDataJson) ?? DefaultCystalariumData;
+            DataLoader.Helper.Data.WriteJsonFile(CrystalariumDataJson, CrystalariumData);
 
             IMailFrameworkModApi mailFrameworkModApi = helper.ModRegistry.GetApi<IMailFrameworkModApi>("DIGUS.MailFrameworkMod");
             mailFrameworkModApi?.RegisterLetter(
@@ -60,8 +55,6 @@ namespace CustomCrystalariumMod
 
         public static void LoadContentPacksCommand(string command = null, string[] args = null)
         {
-            Dictionary<int, string> objects = Helper.GameContent.Load<Dictionary<int, string>>("Data\\ObjectInformation");
-
             foreach (IContentPack contentPack in Helper.ContentPacks.GetOwned())
             {
                 if (File.Exists(Path.Combine(contentPack.DirectoryPath, ClonersDataJson)))
@@ -74,15 +67,16 @@ namespace CustomCrystalariumMod
                         {
                             CustomCrystalariumModEntry.ModMonitor.Log($"The cloner name property can't be null or empty. This cloner will be ignored.", LogLevel.Warn);
                         }
-                        if (cloner.Name == "Crystalarium")
+                        if (cloner.Name == VanillaClonerName || cloner.QualifiedItemId == VanillaClonerQualifiedItemId)
                         {
                             cloner.CloningData.ToList().ForEach(d =>
                             {
-                                int? id = GetId(d.Key, objects);
-                                if (id.HasValue && !CrystalariumDataId.ContainsKey(id.Value))
+                                var (key, value) = d;
+                                var id = GetId(key);
+                                if (id != null && !CrystalariumDataId.ContainsKey(id))
                                 {
-                                    CrystalariumData[d.Key] = d.Value;
-                                    CrystalariumDataId[id.Value] = d.Value;
+                                    CrystalariumData[key] = value;
+                                    CrystalariumDataId[id] = value;
                                     CustomCrystalariumModEntry.ModMonitor.Log($"Adding crystalarium data for item '{d.Key}' from mod '{contentPack.Manifest.UniqueID}'.", LogLevel.Trace);
                                 }
                             });
@@ -90,18 +84,36 @@ namespace CustomCrystalariumMod
                         else
                         {
                             cloner.ModUniqueID = contentPack.Manifest.UniqueID;
-                            if (ClonerController.GetCloner(cloner.Name) is CustomCloner currentCloner)
+                            if (cloner.QualifiedItemId == null)
+                            {
+                                var foundCloner = Game1.bigCraftableData.Where(b => b.Value.Name.Equals(cloner.Name));
+                                if (!foundCloner.Any())
+                                {
+                                    CustomCrystalariumModEntry.ModMonitor.Log($"There is no cloner with the name '{cloner.Name}'. This data will be ignored.", LogLevel.Warn);
+                                    continue;
+                                }
+                                else
+                                {
+                                    cloner.QualifiedItemId = ItemRegistry.type_bigCraftable + foundCloner.First().Key;
+                                    if (foundCloner.Count() > 1)
+                                    {
+                                        CustomCrystalariumModEntry.ModMonitor.Log($"There is more than one big craftable with the name '{cloner.Name}'. Cloner of qualified item id '{cloner.QualifiedItemId}' will be used.", LogLevel.Warn);
+                                    }
+                                }
+                            }
+                            if (ClonerController.GetCloner(cloner.QualifiedItemId) is { } currentCloner)
                             {
                                 if (currentCloner.ModUniqueID != cloner.ModUniqueID)
                                 {
-                                    CustomCrystalariumModEntry.ModMonitor.Log($"Both mods '{currentCloner.ModUniqueID}' and '{cloner.ModUniqueID}' have data for  '{cloner.Name}'. You should report the problem to these mod's authors. Data from mod '{currentCloner.ModUniqueID}' will be used.", LogLevel.Warn);
+                                    CustomCrystalariumModEntry.ModMonitor.Log($"Both mods '{currentCloner.ModUniqueID}' and '{cloner.ModUniqueID}' have data for  '{cloner.Name??cloner.QualifiedItemId}'. You should report the problem to these mod's authors. Data from mod '{currentCloner.ModUniqueID}' will be used.", LogLevel.Warn);
                                     continue;
                                 }
                             }
                             cloner.CloningData.ToList().ForEach(d => 
                             {
-                                int? id = GetId(d.Key, objects);
-                                if (id.HasValue) cloner.CloningDataId[id.Value] = d.Value;
+                                var (key, value) = d;
+                                var id = GetId(key);
+                                if (id != null) cloner.CloningDataId[id] = value;
                             });
                             ClonerController.SetCloner(cloner);
                         }
@@ -109,23 +121,40 @@ namespace CustomCrystalariumMod
                 }
                 else
                 {
-                    CustomCrystalariumModEntry.ModMonitor.Log($"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an CaskData.json file.", LogLevel.Warn);
+                    CustomCrystalariumModEntry.ModMonitor.Log($"Ignoring content pack: {contentPack.Manifest.Name} {contentPack.Manifest.Version} from {contentPack.DirectoryPath}\nIt does not have an {ClonersDataJson} file.", LogLevel.Warn);
                 }
             }
         }
 
-        private static int? GetId(object identifier, Dictionary<int, string> objects)
+        internal static void LoadCrystalariumDataIds()
         {
+            CrystalariumData.ToList().ForEach(d =>
+            {
+                var (key, value) = d;
+                var id = GetId(key);
+                if (id != null)
+                {
+                    CrystalariumDataId[id] = value;
+                }
+            });
+        }
+
+        private static string GetId(object identifier)
+        {
+            if (ItemRegistry.IsQualifiedItemId(identifier.ToString()))
+            {
+                return identifier.ToString();
+            }
             if (Int32.TryParse(identifier.ToString(), out int id))
             {
-                return id;
+                return id >= 0 ? ItemRegistry.QualifyItemId(id.ToString()) : identifier.ToString();
             }
             else
             {
-                KeyValuePair<int, string> pair = objects.FirstOrDefault(o => o.Value.StartsWith(identifier + "/"));
+                var pair = Game1.objectData.FirstOrDefault(o => o.Value.Name.Equals(identifier));
                 if (pair.Value != null)
                 {
-                    return pair.Key;
+                    return ItemRegistry.QualifyItemId(pair.Key);
                 }
             }
             return null;
@@ -136,7 +165,7 @@ namespace CustomCrystalariumMod
             GenericModConfigMenuApi api = Helper.ModRegistry.GetApi<GenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
             if (api != null)
             {
-                api.RegisterModConfig(manifest, () => DataLoader.ModConfig = new ModConfig(), () => Helper.WriteConfig(DataLoader.ModConfig));
+                api.Register(manifest, () => DataLoader.ModConfig = new ModConfig(), () => Helper.WriteConfig(DataLoader.ModConfig));
 
                 api.RegisterSimpleOption(manifest, "Disable Letter", "You won't receive the letter about how the Crystalarium can clone Prismatic Shards and can be tuned to clone more stuff. Needs to restart.", () => DataLoader.ModConfig.DisableLetter, (bool val) => DataLoader.ModConfig.DisableLetter = val);
 
@@ -145,6 +174,8 @@ namespace CustomCrystalariumMod
                 api.RegisterSimpleOption(manifest, "Default Cloning Time", "Cloning time in minutes that will be used for non declared objects.", () => DataLoader.ModConfig.DefaultCloningTime, (int val) => DataLoader.ModConfig.DefaultCloningTime = val);
 
                 api.RegisterSimpleOption(manifest, "Override Cloner Config", "If checked the mod will use the below properties instead of the ones defined for each cloner.", () => DataLoader.ModConfig.OverrideContentPackGetObjectProperties, (bool val) => DataLoader.ModConfig.OverrideContentPackGetObjectProperties = val);
+
+                api.RegisterSimpleOption(manifest, "Keep Quality", "If checked the mod will keep the quality of items placed in the crystalarium.", () => DataLoader.ModConfig.KeepQuality, (bool val) => DataLoader.ModConfig.KeepQuality = val);
 
                 api.RegisterSimpleOption(manifest, "Block Change", "You won't be able to change the object inside. You will need to remove the cloner from the ground.", () => DataLoader.ModConfig.BlockChange, (bool val) => DataLoader.ModConfig.BlockChange = val);
 

--- a/CustomCrystalariumMod/ModConfig.cs
+++ b/CustomCrystalariumMod/ModConfig.cs
@@ -5,7 +5,8 @@
         public bool DisableLetter;
         public bool GetObjectBackOnChange;
         public bool GetObjectBackImmediately;
-        public bool BlockChange;
+        public bool KeepQuality;
+        public bool BlockChange = true;
         public bool EnableCrystalariumCloneEveryObject;
         public int DefaultCloningTime = 5000;
         public bool OverrideContentPackGetObjectProperties;

--- a/CustomCrystalariumMod/ObjectOverrides.cs
+++ b/CustomCrystalariumMod/ObjectOverrides.cs
@@ -1,143 +1,183 @@
 ﻿
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Netcode;
 using StardewValley;
+using StardewValley.Extensions;
+using StardewValley.GameData.Machines;
 using StardewValley.Tools;
+using xTile.Dimensions;
 
 namespace CustomCrystalariumMod
 {
     internal class ObjectOverrides
     {
-        public static bool GetMinutesForCrystalarium(ref int whichGem, ref int __result)
+        public static void OutputMachine(Object __instance, bool probe, Item inputItem, ref bool __result)
         {
-            if (DataLoader.CrystalariumDataId.ContainsKey(whichGem))
+            if (__instance.QualifiedItemId == DataLoader.VanillaClonerQualifiedItemId && !probe)
             {
-                __result = DataLoader.CrystalariumDataId[whichGem];
-                return false;
-            }
-            else
-            {
-                var itemCategory = new Object(whichGem, 1, false).Category;
-                if (DataLoader.CrystalariumDataId.ContainsKey(itemCategory))
+                if (DataLoader.ModConfig.KeepQuality)
                 {
-                    __result = DataLoader.CrystalariumDataId[itemCategory];
-                    return false;
+                    __instance.heldObject.Value.Quality = inputItem.Quality;
                 }
-                else if (DataLoader.ModConfig.EnableCrystalariumCloneEveryObject)
+                if (DataLoader.CrystalariumDataId.TryGetValue(inputItem.QualifiedItemId, out var value))
                 {
-                    __result = DataLoader.ModConfig.DefaultCloningTime;
-                    return false;
+                    __instance.MinutesUntilReady = value;
                 }
-            }
-            return true;
-        }
-
-        public static bool PerformObjectDropInAction(ref Object __instance, ref Item dropInItem, ref bool probe, ref Farmer who, ref bool __result)
-        {
-            if (dropInItem is Object object1)
-            {
-                if (!(__instance.heldObject.Value != null && !__instance.Name.Equals("Recycling Machine") &&
-                      !__instance.Name.Equals("Crystalarium") && !ClonerController.HasCloner(__instance.Name) || object1 != null && (bool)(object1.bigCraftable.Value)))
+                else
                 {
-                    if (__instance.Name.Equals("Crystalarium") || ClonerController.HasCloner(__instance.Name))
+                    var itemCategory = inputItem.Category.ToString();
+                    if (DataLoader.CrystalariumDataId.TryGetValue(itemCategory, out value))
                     {
-                        if (__instance.heldObject.Value == null || (__instance.heldObject.Value.ParentSheetIndex != object1.ParentSheetIndex && __instance.MinutesUntilReady > 0))
-                        {
-                            int minutesUntilReady = 0;
-
-                            Item currentObject = __instance.heldObject.Value;
-
-                            if (__instance.Name.Equals("Crystalarium"))
-                            {
-                                if (DataLoader.CrystalariumDataId.ContainsKey(object1.ParentSheetIndex))
-                                {
-                                    minutesUntilReady = DataLoader.CrystalariumDataId[object1.ParentSheetIndex];
-                                }
-                                else if (DataLoader.CrystalariumDataId.ContainsKey(object1.Category))
-                                {
-                                    minutesUntilReady = DataLoader.CrystalariumDataId[object1.Category];
-                                }
-                                else if ((object1.Category == -2 || object1.Category == -12) && object1.ParentSheetIndex != 74)
-                                {
-                                    minutesUntilReady = DataLoader.Helper.Reflection.GetMethod(__instance, "getMinutesForCrystalarium").Invoke<int>(object1.ParentSheetIndex);
-                                }
-                                else if (DataLoader.ModConfig.EnableCrystalariumCloneEveryObject)
-                                {
-                                    minutesUntilReady = DataLoader.ModConfig.DefaultCloningTime;
-                                }
-                                else
-                                {
-                                    return true;
-                                }
-                                if (DataLoader.ModConfig.BlockChange && currentObject != null)
-                                {
-                                    ShowBlockChangeDialog();
-                                    __result = false;
-                                    return false;
-                                }
-                            }
-                            else if (ClonerController.GetCloner(__instance.Name) is CustomCloner cloner)
-                            {
-                                if (cloner.UsePfmForInput) return true;
-                                var clonerMinutes = ClonerController.GetMinutesUntilReady(cloner, object1);
-                                if (clonerMinutes.HasValue)
-                                {
-                                    minutesUntilReady = clonerMinutes.Value;
-                                }
-                                else
-                                {
-                                    return true;
-                                }
-                                if ((DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.BlockChange : cloner.BlockChange) && currentObject != null)
-                                {
-                                    ShowBlockChangeDialog();
-                                    __result = false;
-                                    return false;
-                                }
-                            }
-                            if (__instance.bigCraftable.Value && !probe &&
-                                (object1 != null && __instance.heldObject.Value == null))
-                            {
-                                __instance.scale.X = 5f;
-                            }
-                            __instance.heldObject.Value = (Object)object1.getOne();
-                            if (!probe)
-                            {
-                                who.currentLocation.playSound("select");
-                                __instance.MinutesUntilReady = minutesUntilReady;
-                                if (__instance.Name.Equals("Crystalarium") || DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.GetObjectBackImmediately : ClonerController.GetCloner(__instance.Name).GetObjectBackImmediately)
-                                {
-                                    __instance.MinutesUntilReady = 0;
-                                    __instance.minutesElapsed(0, who.currentLocation);
-                                }
-                                else if (currentObject != null && (__instance.Name.Equals("Crystalarium") || DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.GetObjectBackOnChange : ClonerController.GetCloner(__instance.Name).GetObjectBackOnChange))
-                                {
-                                    who.addItemByMenuIfNecessary(currentObject.getOne());
-                                }
-                                __instance.initializeLightSource(__instance.TileLocation, false);
-                            }
-                            __result = true;
-                            return false;
-                        }
+                        __instance.MinutesUntilReady = value;
+                    }
+                    else if (DataLoader.ModConfig.EnableCrystalariumCloneEveryObject && !inputItem.HasTypeBigCraftable())
+                    {
+                        __instance.MinutesUntilReady = DataLoader.ModConfig.DefaultCloningTime;
                     }
                 }
+            }               
+            return;
+        }
+
+        public static bool PerformObjectDropInAction(ref Object __instance, ref Item dropInItem, ref bool probe, ref Farmer who, ref bool returnFalseIfItemConsumed, ref bool __result)
+        {
+            if (dropInItem is Object object1 && !__instance.isTemporarilyInvisible && !__instance.IsSprinkler())
+            {
+                if (IsCrystalarium(__instance) || ClonerController.HasCloner(__instance.QualifiedItemId))
+                {
+                    if (__instance.heldObject.Value == null || (__instance.heldObject.Value.ItemId != object1.ItemId && __instance.MinutesUntilReady > 0))
+                    {
+                        int minutesUntilReady = 0;
+
+                        Item currentObject = __instance.heldObject.Value;
+
+                        if (IsCrystalarium(__instance))
+                        {
+                            if (dropInItem.QualifiedItemId == "(O)872" && Object.autoLoadFrom == null)
+                            {
+                                return true;
+                            }
+                            if (DataLoader.CrystalariumDataId.TryGetValue(object1.QualifiedItemId, out var value))
+                            {
+                                minutesUntilReady = value;
+                            }
+                            else if (DataLoader.CrystalariumDataId.TryGetValue(object1.Category.ToString(), out value))
+                            {
+                                minutesUntilReady = value;
+                            }
+                            else if (object1.Category is -2 or -12 && object1.ParentSheetIndex != 74)
+                            {
+                                MachineData machineData = __instance.GetMachineData();
+                                minutesUntilReady = (int)Utility.ApplyQuantityModifiers(machineData.OutputRules.Find(r=> r.Id== "Default").MinutesUntilReady, __instance.GetMachineData().ReadyTimeModifiers, __instance.GetMachineData().ReadyTimeModifierMode, __instance.Location, who, object1, object1);
+                            }
+                            else if (DataLoader.ModConfig.EnableCrystalariumCloneEveryObject && !object1.HasTypeBigCraftable())
+                            {
+                                minutesUntilReady = DataLoader.ModConfig.DefaultCloningTime;
+                            }
+                            else
+                            {
+                                return true;
+                            }
+                            if (DataLoader.ModConfig.BlockChange && currentObject != null)
+                            {
+                                ShowBlockChangeDialog();
+                                __result = false;
+                                return false;
+                            }
+                        }
+                        else if (ClonerController.GetCloner(__instance.QualifiedItemId) is { } cloner)
+                        {
+                            if (cloner.UsePfmForInput) return true;
+                            var clonerMinutes = ClonerController.GetMinutesUntilReady(cloner, object1);
+                            if (clonerMinutes.HasValue)
+                            {
+                                minutesUntilReady = clonerMinutes.Value;
+                            }
+                            else
+                            {
+                                return true;
+                            }
+                            if ((DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.BlockChange : cloner.BlockChange) && currentObject != null)
+                            {
+                                ShowBlockChangeDialog();
+                                __result = false;
+                                return false;
+                            }
+                        }
+                        if (__instance.bigCraftable.Value && !probe &&
+                            (object1 != null && __instance.heldObject.Value == null))
+                        {
+                            __instance.scale.X = 5f;
+                        }
+                        if (!probe)
+                        {
+                            __instance.heldObject.Value = (Object)object1.getOne();
+                            if ((IsCrystalarium(__instance) && !DataLoader.ModConfig.KeepQuality) || (ClonerController.GetCloner(__instance.QualifiedItemId) !=null && !ClonerController.GetCloner(__instance.QualifiedItemId).KeepQuality))
+                            {
+                                __instance.heldObject.Value.Quality = 0;
+                            }
+                            who.currentLocation.playSound("select");
+                            __instance.MinutesUntilReady = minutesUntilReady;
+                            Object.ConsumeInventoryItem(who, dropInItem, 1);
+                            if (IsCrystalarium(__instance) || DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.GetObjectBackImmediately : ClonerController.GetCloner(__instance.QualifiedItemId).GetObjectBackImmediately)
+                            {
+                                __instance.MinutesUntilReady = 0;
+                                __instance.minutesElapsed(0);
+                            }
+                            else if (currentObject != null && (IsCrystalarium(__instance) || DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? DataLoader.ModConfig.GetObjectBackOnChange : ClonerController.GetCloner(__instance.Name).GetObjectBackOnChange))
+                            {
+                                who.addItemByMenuIfNecessary(currentObject.getOne());
+                            }
+                            if (object1 != null)
+                            {
+                                __instance.lastInputItem.Value = object1.getOne();
+                                __instance.lastInputItem.Value.Stack = 1;
+                            }
+                            else
+                            {
+                                __instance.lastInputItem.Value = null;
+                            }
+                            __instance.initializeLightSource(__instance.TileLocation, false);
+                            var machineData = __instance.GetMachineData();
+                            if (machineData?.LoadEffects != null)
+                            {
+                                foreach (MachineEffects effect in machineData.LoadEffects)
+                                {
+                                    if (__instance.PlayMachineEffect(effect, true))
+                                    {
+                                        break;
+                                    }
+                                }
+                            }
+                            MachineDataUtility.UpdateStats(machineData?.StatsToIncrementWhenLoaded, object1, 1);
+                            __result = !returnFalseIfItemConsumed;
+                        }
+                        else
+                        {
+                            __result = true;
+                        }
+                        return false;
+                    }
+                }
+                
             }
             return true;
         }
 
-        public static bool PerformRemoveAction(ref Object __instance, ref Vector2 tileLocation, GameLocation environment)
+        public static bool PerformRemoveAction(ref Object __instance)
         {
-            if (ClonerController.GetCloner(__instance.Name) is CustomCloner cloner)
+            if (ClonerController.GetCloner(__instance.Name) is { } cloner)
             {
                 if (__instance.heldObject.Value != null)
                 {
                     if (DataLoader.ModConfig.OverrideContentPackGetObjectProperties ? !DataLoader.ModConfig.GetObjectBackImmediately : !cloner.GetObjectBackImmediately)
                     {
-                        environment.debris.Add(new Debris((Object) __instance.heldObject.Value, __instance.TileLocation * 64f + new Vector2(32f, 32f)));
+                        __instance.Location.debris.Add(new Debris((Object) __instance.heldObject.Value, __instance.TileLocation * 64f + new Vector2(32f, 32f)));
                     }
 
                     __instance.heldObject.Value = null;
@@ -146,14 +186,14 @@ namespace CustomCrystalariumMod
             return true;
         }
 
-        public static bool PerformToolAction(ref Object __instance, Tool t, GameLocation location)
+        public static bool PerformToolAction(ref Object __instance, Tool t)
         {
             if (__instance.isTemporarilyInvisible || t == null)
             {
                 return true;
             }
 
-            if (__instance.Type != null && __instance.Type.Equals("Crafting") && !(t is MeleeWeapon) && t.isHeavyHitter())
+            if (__instance.Type is "Crafting" && t is not MeleeWeapon && t.isHeavyHitter())
             {
                 if ((bool)__instance.bigCraftable.Value && __instance.ParentSheetIndex == 21 && __instance.heldObject.Value != null)
                 {
@@ -174,7 +214,7 @@ namespace CustomCrystalariumMod
 
         public static void CheckForAction_postfix(ref Object __instance, Object __state, bool justCheckingForActivity)
         {
-            if (ClonerController.GetCloner(__instance.Name) is CustomCloner cloner && __instance.Name != "Crystalarium" && __state != null && !justCheckingForActivity)
+            if (ClonerController.GetCloner(__instance.QualifiedItemId) is { } cloner && __instance.Name != "Crystalarium" && __state != null && !justCheckingForActivity)
             {
                 __instance.MinutesUntilReady = ClonerController.GetMinutesUntilReady(cloner, __state) ?? __instance.MinutesUntilReady;
                 if (__instance.MinutesUntilReady != 0)
@@ -185,10 +225,32 @@ namespace CustomCrystalariumMod
             }
         }
 
+        internal static bool TryApplyFairyDust(Object __instance, bool probe, ref bool __result)
+        {
+            if (__instance.GetMachineData() != null) return true;
+            if (__instance.MinutesUntilReady <= 0) return true;
+            if (ClonerController.GetCloner(__instance.QualifiedItemId) is null) return true;
+            if (!probe)
+            {
+                Utility.addSprinklesToLocation(__instance.Location, (int)__instance.TileLocation.X,
+                    (int)__instance.TileLocation.Y, 1, 2, 400, 40, Color.White);
+                Game1.playSound("yoba");
+                __instance.MinutesUntilReady = 0;
+                __instance.minutesElapsed(0);
+            }
+            __result = true;
+            return false;
+        }
+
         private static void ShowBlockChangeDialog()
         {
             string dialogue = DataLoader.I18N.Get("CustomCrystalarium.Dialogue.BlockChange");
             Game1.showRedMessage(dialogue);
+        }
+
+        private static bool IsCrystalarium(Object instance)
+        {
+            return instance.QualifiedItemId.Equals(DataLoader.VanillaClonerQualifiedItemId);
         }
     }
 }

--- a/CustomCrystalariumMod/contentPackTemplate/ClonersData.json
+++ b/CustomCrystalariumMod/contentPackTemplate/ClonersData.json
@@ -1,14 +1,17 @@
 ﻿[
     {
-        "Name": "Grave Stone", //Name of the cloner. Required.
+        "Name": "Grave Stone", //Name of the cloner.
+        "QualifiedItemId": "(BC)21", //The QualifiedItemId of the cloner. It's required if no Name is defined.
         "EnableCloneEveryObject": false, //If true, the cloner will be able to clone every object. Default is false.
         "DefaultCloningTime": 5000, //Cloning time use for undefined objects when enable clone every object is true. Default is 5000.
         "GetObjectBackOnChange": true, //If true, you'll get the item you placed before back from the cloner when you place a new item or remove the cloner from the ground. Default is false.
         "GetObjectBackImmediately": false, //If true, the cloner will let you get the item you placed back immediately. Also, the ﻿GetObjectBackOnChange option will be ignored. Default is false.
+        "KeepQuality": true, // If true, the quality will be kept for the cloned objects. Default true;
         "BlockChange": false, //If true, you won't be able to change the object inside. You will need to remove the cloner from the ground. Default is false. 
         "UsePfmForInput": false, // If true, it won't let you place the object listed on CloningData into the cloner. You will need PFM to create input rules, and the cloning data will be used to restart the machine when the output is picked up.
         "CloningData": { // Pair of identifier and time in game minutes for the object to be cloned. The identifier can be the Index, the Category or the Name of the object.
             "Peach": 10, //Name identifier
+            "(O)74": 10, //Qualified Item Id identifier
             "136": 30, //Index identifier
             "-5": 60 //Category identifier
         }

--- a/CustomCrystalariumMod/contentPackTemplate/manifest.json
+++ b/CustomCrystalariumMod/contentPackTemplate/manifest.json
@@ -4,7 +4,7 @@
 	"Version": "1.0.0",
 	"Description": "Adds configuration of my cloner data to Custom Crystalarium Mod.",
 	"UniqueID": "YourName.YouPackNameForCustomCrystalariumMod",
-	"MinimumApiVersion": "3.18.0",
+	"MinimumApiVersion": "4.0.0",
 	"UpdateKeys": [],
 	"Dependencies": [
 		{

--- a/CustomCrystalariumMod/integrations/GenericModConfigMenuApi.cs
+++ b/CustomCrystalariumMod/integrations/GenericModConfigMenuApi.cs
@@ -5,7 +5,7 @@ namespace CustomCrystalariumMod.integrations
 {
     public interface GenericModConfigMenuApi
     {
-        void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
+        void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
         void RegisterLabel(IManifest mod, string labelName, string labelDesc);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);

--- a/CustomCrystalariumMod/manifest.json
+++ b/CustomCrystalariumMod/manifest.json
@@ -1,15 +1,15 @@
 ﻿{
     "Name": "Custom Crystalarium Mod",
     "Author": "Digus",
-    "Version": "1.4.2",
+    "Version": "1.5.0",
     "Description": "Adds a way to customize the crystalarium machine. Adds a way to create custom cloners using content packs.",
     "UniqueID": "DIGUS.CustomCrystalariumMod",
     "EntryDll": "CustomCrystalariumMod.dll",
-    "MinimumApiVersion": "3.18.0",
+    "MinimumApiVersion": "4.0.0",
     "Dependencies": [
         {
             "UniqueID": "DIGUS.MailFrameworkMod",
-            "MinimumVersion": "1.15.0",
+            "MinimumVersion": "1.16.0",
             "IsRequired": false
         }
     ],


### PR DESCRIPTION
- Update mod to work with Stardew Valley 1.6
- Custom Cloner can now be defined by QualifiedItemId.
- Clonables can now be defined by QualifiedItemId.
- Clonables are now kept by their QualifiedItemId internaly.
- New property KeepQuality. Crystalarium and cloners kept the quality by default before SV 1.6 Don't know if it will be fixed, but this property solves this "bug".
- Updates to .net6
- Patch to keep fairy dust functionality
- Content packs now wait 120 ticks to be loaded the first time.
- Update Generic Mod Config Menu api
- BlockChange nows default to true since that is the vanilla behavior