### PR TITLE
Mail Framework Mod 1.17.0

### DIFF
--- a/MailFrameworkMod/ContentPack/Attachment.cs
+++ b/MailFrameworkMod/ContentPack/Attachment.cs
@@ -5,6 +5,7 @@
         public ItemType Type;
         public string Index;
         public int? Stack;
+        public int Quality;
         public string Name;
         public int? UpgradeLevel;
     }

--- a/MailFrameworkMod/ContentPackTemplate/mail.json
+++ b/MailFrameworkMod/ContentPackTemplate/mail.json
@@ -9,7 +9,8 @@
 				"Type": "Object", // [Object|BigCraftable|Tool|Ring|Furniture|Weapon|Boots|DGA|FullId] Required. The type of item that will be attached. If not provided the item will be ignored.
 				"Name": "Cave Carrot", // Used to find the item index. That's required if using custom objects like Json Assets ones. Should be the full DGA ID is using DGA. If not provided, the index will be used. Default is null.
 				"Index": "(0)78", // The index of an item. Should be the qualified item id as a string, but will also work as an integer for retro compatibility. If no name is provided or an item for the name is not found, the index is used. Otherwise, the attachment is ignored. Ignored if the type is DGA.
-				"Stack": 1 // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
+				"Stack": 1, // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1.
+				"Quality": 2 // The quality value of the item to be delivered. Used only for Objects. 0 = none, 1 = silver, 2 = gold, 4 = iridium. Default is 0; 
 			},
 			{
 				"Type": "Tool", // When using tool, only supported ones can be attached.
@@ -19,12 +20,14 @@
 			{
 				"Type": "DGA", //DGA item
 				"Name": "spacechase0.DynamicGameAssets.Example/My Custom Item", // use the full DGA ID. Required.
-				"Stack": 10 // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
+				"Stack": 10, // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1.				
+				"Quality": 2 // The quality value of the item to be delivered. Used only for Objects. 0 = none, 1 = silver, 2 = gold, 4 = iridium. Default is 0; 
 			},
 			{
 				"Type": "QualifiedItemId", //Any supported item
 				"Index": "(0)78", // The Qualified Item Id of an item.
-				"Stack": 10 // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
+				"Stack": 10, // The stack value of the item to be delivered. Used only for Objects and BigCraftable. Default is 1;
+				"Quality": 2 // The quality value of the item to be delivered. Used only for Objects. 0 = none, 1 = silver, 2 = gold, 4 = iridium. Default is 0; 
 			}
 		],
 		"Recipe": "Recipe Name", // Remove the line if you don't want to attach a recipe to the mail. It will only work if you have no other attachments to the mail. For DGA recipes only use the ID part (leave away the ModID)

--- a/MailFrameworkMod/DataLoader.cs
+++ b/MailFrameworkMod/DataLoader.cs
@@ -122,8 +122,10 @@ namespace MailFrameworkMod
                     })) continue;
 
                     bool Condition(Letter l) =>
-                        (!Game1.player.mailReceived.Contains(l.Id) || mailItem.Repeatable)
-                        && (mailItem.Recipe == null || !Game1.player.cookingRecipes.ContainsKey(mailItem.Recipe))
+                        (!Game1.player.mailReceived.Contains(l.Id) || mailItem.Repeatable || mailItem.Recipe != null)
+                        && (mailItem.Recipe == null || !(Game1.player.cookingRecipes.ContainsKey(mailItem.Recipe) 
+                                                    || Game1.player.craftingRecipes.ContainsKey(mailItem.Recipe)
+                                                    || Game1.player.craftingRecipes.ContainsKey(CraftingRecipe.craftingRecipes.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == mailItem.Recipe).Select(r=>r.Key).FirstOrDefault()??"")))
                         && (mailItem.Date == null || SDate.Now() >= new SDate(Convert.ToInt32(mailItem.Date.Split(' ')[0]),
                                 mailItem.Date.Split(' ')[1], Convert.ToInt32(mailItem.Date.Split(' ')[2].Replace("Y", ""))))
                         && (mailItem.Days == null || mailItem.Days.Contains(SDate.Now().Day))
@@ -229,7 +231,7 @@ namespace MailFrameworkMod
 
                                     if (i.Index != null)
                                     {
-                                        attachments.Add(new StardewValley.Object(i.Index, i.Stack ?? 1));
+                                        attachments.Add(new StardewValley.Object(i.Index, i.Stack ?? 1, quality: i.Quality));
                                     }
                                     else
                                     {
@@ -417,7 +419,7 @@ namespace MailFrameworkMod
                                     {
                                         string index = i.Index;
                                         attachments.Add(SlingshotIndexes.Contains(index)
-                                            ? (Item) new Slingshot(index)
+                                            ? (Item) new Slingshot(index.Replace("(W)",""))
                                             : (Item) new MeleeWeapon(index));
                                     }
                                     else
@@ -468,6 +470,7 @@ namespace MailFrameworkMod
                                                 if (dgaItem is StardewValley.Object)
                                                 {
                                                     dgaItem.Stack = i.Stack ?? 1;
+                                                    dgaItem.Quality = i.Quality;
                                                 }
                                                 else
                                                 {
@@ -502,7 +505,7 @@ namespace MailFrameworkMod
                                 case ItemType.QualifiedItemId:
                                     if (i.Index != null)
                                     {
-                                        Item item = ItemRegistry.Create(i.Index, i.Stack ?? 1);
+                                        Item item = ItemRegistry.Create(i.Index, i.Stack ?? 1, i.Quality);
                                         attachments.Add(item);
                                     }
                                     else

--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -263,7 +263,7 @@ namespace MailFrameworkMod
                 learnedRecipe = new CraftingRecipe(recipe, isCookingRecipe: true).DisplayName;
                 cookingOrCraftingText =  Game1.content.LoadString("Strings\\UI:LearnedRecipe_cooking");
             }
-            else if (craftingData.ContainsKey(recipe))
+            else if (craftingData.ContainsKey(recipe) || craftingData.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == recipe).Any(r=>{recipe = r.Key; return true;}))
             {
                 if (!Game1.player.craftingRecipes.ContainsKey(recipe))
                 {

--- a/MailFrameworkMod/manifest.json
+++ b/MailFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
 	"Name": "Mail Framework Mod",
 	"Author": "Digus",
-	"Version": "1.16.1",
+	"Version": "1.17.0",
 	"MinimumApiVersion": "4.0.0",
 	"Description": "Utility classes to send mail in the game.",
 	"UniqueID": "DIGUS.MailFrameworkMod",


### PR DESCRIPTION
- New property to set the quality of the attachment
- Content pack mails with recipe should now should be redelivered until the recipe is learned.
- Fix warnings about Slingshot
- Fix recipes for craftables been delivered even if the recipe was already learned.
- For legacy reasons, if the recipe id is not found in the learned recipes, it will look for a recipe that create an item with the name of the recipe id.