### PR TITLE
Animal Husbandry Mod 2.6.10

### DIFF
--- a/ButcherMod/AnimalHusbandryMod.csproj
+++ b/ButcherMod/AnimalHusbandryMod.csproj
@@ -20,16 +20,6 @@
     <None Remove="Properties\**" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="contentPackTemplate\customAnimals.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/ButcherMod/animals/FarmAnimalExtension.cs
+++ b/ButcherMod/animals/FarmAnimalExtension.cs
@@ -112,7 +112,7 @@ namespace AnimalHusbandryMod.animals
 
         private static string GetKey(this Character character, string key)
         {
-            if (character.modData.TryGetValue(key, out string value))
+            if (character.modData != null && character.modData.TryGetValue(key, out string value))
                 return value;
             else
                 return null;

--- a/ButcherMod/animals/MeatController.cs
+++ b/ButcherMod/animals/MeatController.cs
@@ -155,7 +155,7 @@ namespace AnimalHusbandryMod.animals
 
                 for (; numberOfWools > 0; --numberOfWools)
                 {
-                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.currentProduce.Value, 1, ProduceQuality(random, farmAnimal));
+                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetProduceID(random, false), 1, ProduceQuality(random, farmAnimal));
                     itemsToReturn.Add(newItem);
                 }
             }

--- a/ButcherMod/common/DataLoader.cs
+++ b/ButcherMod/common/DataLoader.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using AnimalHusbandryMod.animals;
 using AnimalHusbandryMod.animals.data;
 using AnimalHusbandryMod.cooking;
@@ -424,7 +423,7 @@ namespace AnimalHusbandryMod.common
             {
                 api.Register(manifest, () => DataLoader.ModConfig = new ModConfig(), () => Helper.WriteConfig(DataLoader.ModConfig));
 
-                api.RegisterLabel(manifest, "Main Features:", "Properties to disable the mod main features.");
+                api.AddSectionTitle(manifest, () => "Main Features:", () => "Properties to disable the mod main features.");
 
                 api.RegisterSimpleOption(manifest, "Disable Meat", "Disable all features related to meat. Meat Cleaver/Wand will not be delivered , and if already owned, will not work. Meat items and meat dishes will not be loaded. Any item still on the inventory will be bugged. You should sell/trash all of them before disabling meat. Meat Friday will not show on TV. You will not receive any more meat recipe letter from the villagers. Learned recipes will still be known, but will not show on the cooking menu. If re-enabled, they will show again. Restart the game after changing this.", () => DataLoader.ModConfig.DisableMeat, (bool val) => DataLoader.ModConfig.DisableMeat = val);
                 
@@ -434,7 +433,7 @@ namespace AnimalHusbandryMod.common
                 
                 api.RegisterSimpleOption(manifest, "Disable Animal Contest", "Disable all features related to the animal contest. You won't receive any more participant ribbons. Bonus from previous winners will still apply though. Restart the game after changing this.", () => DataLoader.ModConfig.DisableAnimalContest, (bool val) => DataLoader.ModConfig.DisableAnimalContest = val);
 
-                api.RegisterLabel(manifest, "Meat Properties:", "Properties to configure the meat feature.");
+                api.AddSectionTitle(manifest, () => "Meat Properties:", () => "Properties to configure the meat feature.");
 
                 api.RegisterSimpleOption(manifest, "Softmode", "Enable the Softmode. When enabled the Meat Cleaver is replaced with the Meat Want. They work the same, but sound, text and effects are changed to resemble magic. Restart the game after changing this.", () => DataLoader.ModConfig.Softmode, (bool val) => DataLoader.ModConfig.Softmode = val);
 
@@ -450,7 +449,7 @@ namespace AnimalHusbandryMod.common
 
                 api.RegisterSimpleOption(manifest, "Add Meat Tool Key", "Set a keyboard key to directly add the Meat Cleaver/Want to your inventory.", () => DataLoader.ModConfig.AddMeatCleaverToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddMeatCleaverToInventoryKey = val == SButton.None ? (SButton?)null : val);
 
-                api.RegisterLabel(manifest, "Pregnancy Properties:", "Properties to configure the insemination feature.");
+                api.AddSectionTitle(manifest, () => "Pregnancy Properties:", () => "Properties to configure the insemination feature.");
 
                 api.RegisterSimpleOption(manifest, "Disable Full Build Notif.", "Disable notifications for when an animals can't give birth because their building is full.", () => DataLoader.ModConfig.DisableFullBuildingForBirthNotification, (bool val) => DataLoader.ModConfig.DisableFullBuildingForBirthNotification = val);
                 
@@ -458,7 +457,7 @@ namespace AnimalHusbandryMod.common
 
                 api.RegisterSimpleOption(manifest, "Add Insemination Syringe Key", "Set a keyboard key to directly add the Insemination Syringe to your inventory.", () => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey = val == SButton.None ? (SButton?)null : val);
 
-                api.RegisterLabel(manifest, "Treats Properties:", "Properties to configure the treats feature.");
+                api.AddSectionTitle(manifest, () => "Treats Properties:", () => "Properties to configure the treats feature.");
 
                 api.RegisterSimpleOption(manifest, "Disable Friendship Increase", "Disable animal friendship being increased when given a treat.", () => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats, (bool val) => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats = val);
 
@@ -470,11 +469,11 @@ namespace AnimalHusbandryMod.common
 
                 api.RegisterSimpleOption(manifest, "Add Feeding Basket Key", "Set a keyboard key to directly add the Feeding Basket to your inventory.", () => DataLoader.ModConfig.AddFeedingBasketToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddFeedingBasketToInventoryKey = val == SButton.None ? (SButton?) null : val);
 
-                api.RegisterLabel(manifest, "Animal Contest Properties:", "Properties to configure the animal contest feature.");
+                api.AddSectionTitle(manifest, () => "Animal Contest Properties:", () => "Properties to configure the animal contest feature.");
 
                 api.RegisterSimpleOption(manifest, "Disable Contest Bonus", "Disable the fertility and the production bonuses from the contest. If enabled again, all winners will receive the bonus again, no matter if the bonus was disabled when they won.", () => DataLoader.ModConfig.DisableContestBonus, (bool val) => DataLoader.ModConfig.DisableContestBonus = val);
 
-                api.RegisterLabel(manifest, "Misc. Properties:", "Miscellaneous Properties.");
+                api.AddSectionTitle(manifest, () => "Misc. Properties:", () => "Miscellaneous Properties.");
 
                 api.RegisterSimpleOption(manifest, "Force Draw Attachment", "Force the patch that draw the hover menu for the feeding basket and insemination syringe on any OS. Restart the game after changing this.", () => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS, (bool val) => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS = val);
 

--- a/ButcherMod/farmer/FarmerData.cs
+++ b/ButcherMod/farmer/FarmerData.cs
@@ -2,6 +2,7 @@
 using AnimalHusbandryMod.animals.data;
 using System.Collections.Generic;
 using AnimalHusbandryMod.animals;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace AnimalHusbandryMod.farmer
 {

--- a/ButcherMod/farmer/FarmerLoader.cs
+++ b/ButcherMod/farmer/FarmerLoader.cs
@@ -9,6 +9,7 @@ using AnimalHusbandryMod.common;
 using StardewModdingAPI.Utilities;
 using StardewValley;
 using DataLoader = AnimalHusbandryMod.common.DataLoader;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace AnimalHusbandryMod.farmer
 {

--- a/ButcherMod/integrations/GenericModConfigMenuApi.cs
+++ b/ButcherMod/integrations/GenericModConfigMenuApi.cs
@@ -19,15 +19,13 @@ namespace AnimalHusbandryMod.integrations
         /// <remarks>Each mod can only be registered once, unless it's deleted via <see cref="Unregister"/> before calling this again.</remarks>
         void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
 
-        void StartNewPage(IManifest mod, string pageName);
-        void OverridePageDisplayName(IManifest mod, string pageName, string displayName);
-
-        void RegisterLabel(IManifest mod, string labelName, string labelDesc);
-        void RegisterPageLabel(IManifest mod, string labelName, string labelDesc, string newPage);
-        void RegisterParagraph(IManifest mod, string paragraph);
+        /// <summary>Add a section title at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The title text shown in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
+        void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
 
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
         void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
     }

--- a/ButcherMod/manifest.json
+++ b/ButcherMod/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
    "Name": "Animal Husbandry Mod",
    "Author": "Digus",
-   "Version": "2.6.9",
+   "Version": "2.6.10",
    "Description": "Adds features related to animal husbandry.",
    "UniqueID": "DIGUS.ANIMALHUSBANDRYMOD",
    "EntryDll": "AnimalHusbandryMod.dll",
-   "MinimumApiVersion": "3.8.0",
+   "MinimumApiVersion": "4.0.0",
    "Dependencies": [
       { "UniqueID": "DIGUS.MailFrameworkMod", "MinimumVersion": "1.16.0" },
       { "UniqueID": "spacechase0.GenericModConfigMenu", "MinimumVersion": "1.12.0", "IsRequired": false }

--- a/ButcherMod/tools/ParticipantRibbonOverrides.cs
+++ b/ButcherMod/tools/ParticipantRibbonOverrides.cs
@@ -131,7 +131,7 @@ namespace AnimalHusbandryMod.tools
                 {
                     dialogue = DataLoader.i18n.Get("Tool.ParticipantRibbon.IsAlreadyParticipant", new { animalName = animal.displayName });
                 }
-                else if (AnimalContestController.GetNextContestParticipant() is Character participant)
+                else if (AnimalContestController.GetNextContestParticipant() is { } participant)
                 {
                     string participantName = participant.displayName;
                     dialogue = DataLoader.i18n.Get("Tool.ParticipantRibbon.AnotherParticipantAlready", new { participantName });


### PR DESCRIPTION
- Updating dependencies
- Marking deprecated warning on converting code
- Fix null reference when reading modData from farmAnimals
- Fix bug where exchange a shorn sheep would give null reference error.
- Updating to new api of GMCM