### PR TITLE
Mail Framework Mod 1.17.1

### DIFF
--- a/MailFrameworkMod/DataLoader.cs
+++ b/MailFrameworkMod/DataLoader.cs
@@ -122,10 +122,11 @@ namespace MailFrameworkMod
                     })) continue;
 
                     bool Condition(Letter l) =>
-                        (!Game1.player.mailReceived.Contains(l.Id) || mailItem.Repeatable || mailItem.Recipe != null)
+                        (!Game1.player.mailReceived.Contains(l.Id) || mailItem.Repeatable || (mailItem.Recipe != null && mailItem.Attachments?.Count == 0))
                         && (mailItem.Recipe == null || !(Game1.player.cookingRecipes.ContainsKey(mailItem.Recipe) 
                                                     || Game1.player.craftingRecipes.ContainsKey(mailItem.Recipe)
-                                                    || Game1.player.craftingRecipes.ContainsKey(CraftingRecipe.craftingRecipes.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == mailItem.Recipe).Select(r=>r.Key).FirstOrDefault()??"")))
+                                                    || Game1.player.cookingRecipes.ContainsKey(CraftingRecipe.cookingRecipes.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == mailItem.Recipe).Select(r=>r.Key).FirstOrDefault()??"")
+                                                    || Game1.player.craftingRecipes.ContainsKey(CraftingRecipe.craftingRecipes.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == mailItem.Recipe).Select(r => r.Key).FirstOrDefault() ?? "")))
                         && (mailItem.Date == null || SDate.Now() >= new SDate(Convert.ToInt32(mailItem.Date.Split(' ')[0]),
                                 mailItem.Date.Split(' ')[1], Convert.ToInt32(mailItem.Date.Split(' ')[2].Replace("Y", ""))))
                         && (mailItem.Days == null || mailItem.Days.Contains(SDate.Now().Day))

--- a/MailFrameworkMod/MailController.cs
+++ b/MailFrameworkMod/MailController.cs
@@ -253,7 +253,7 @@ namespace MailFrameworkMod
             Dictionary<string, string> craftingData = StardewValley.DataLoader.CraftingRecipes(Game1.content);
             learnedRecipe = null;
             cookingOrCraftingText = null;
-            if (cookingData.ContainsKey(recipe))
+            if (cookingData.ContainsKey(recipe) || cookingData.Where(r => ItemRegistry.GetData(r.Value.Split("/")[2].Split(" ")[0])?.InternalName == recipe).Any(r => { recipe = r.Key; return true; }))
             {
                 if (!Game1.player.cookingRecipes.ContainsKey(recipe))
                 {

--- a/MailFrameworkMod/manifest.json
+++ b/MailFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
 	"Name": "Mail Framework Mod",
 	"Author": "Digus",
-	"Version": "1.17.0",
+	"Version": "1.17.1",
 	"MinimumApiVersion": "4.0.0",
 	"Description": "Utility classes to send mail in the game.",
 	"UniqueID": "DIGUS.MailFrameworkMod",


### PR DESCRIPTION
- Content pack mails with recipe need to not have attachments for be redelivered if the recipe is not learned.
- Fix cooking recipes with the same logic applied to crafting recipes before.