### PR TITLE
Producer Framework Mod 1.9.3

### DIFF
--- a/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
+++ b/ProducerFrameworkMod/Api/ProducerFrameworkModApi.cs
@@ -22,7 +22,7 @@ namespace ProducerFrameworkMod.Api
 
         public List<Dictionary<string, object>> GetRecipes(string producerName)
         {
-            var key = Game1.bigCraftableData.FirstOrDefault(b => b.Value.Name.Equals(producerName)).Key;
+            var key = Game1.bigCraftableData.FirstOrDefault(b => producerName.Equals(b.Value.Name)).Key;
             var producerRules = key != null
                 ? ProducerController.GetProducerRules(ItemRegistry.type_bigCraftable + key)
                 : null;
@@ -145,7 +145,7 @@ namespace ProducerFrameworkMod.Api
 
         public List<ProducerRule> GetProducerRules(string producerName)
         {
-            var key = Game1.bigCraftableData.FirstOrDefault(b => b.Value.Name.Equals(producerName)).Key;
+            var key = Game1.bigCraftableData.FirstOrDefault(b => producerName.Equals(b.Value.Name)).Key;
             return key != null ? ProducerController.GetProducerRules(ItemRegistry.type_bigCraftable + key) : null;
         }
 

--- a/ProducerFrameworkMod/Controllers/ProducerController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerController.cs
@@ -17,33 +17,12 @@ namespace ProducerFrameworkMod.Controllers
     public class ProducerController
     {
         public static readonly List<string> UnsupportedMachines = new()
-            { "(BC)21", "(BC)163", "(BC)101", "(BC)156", "(BC)275", "(BC)130", "(BC)62", "(BC)209"
-                , "(BC)208", "(BC)105", "(BC)264", "(BC)94", "(BC)127", "(BC)56", "(BC)71", "(BC)159", "(BC)141"
-                , "(BC)8", "(BC)167", "(BC)110", "(BC)113", "(BC)126", "(BC)136", "(BC)137", "(BC)138", "(BC)139", "(BC)140" //arecrow
-            };
+        {
+            "(BC)0", "(BC)1", "(BC)2", "(BC)3", "(BC)4", "(BC)5", "(BC)6", "(BC)7", "(BC)8", "(BC)21", "(BC)56", "(BC)62", "(BC)71", "(BC)94", "(BC)99", "(BC)101", "(BC)105", "(BC)110", "(BC)113", "(BC)126", "(BC)127", "(BC)130", "(BC)136", "(BC)137", "(BC)138", "(BC)139", "(BC)140", "(BC)141", "(BC)156", "(BC)159", "(BC)163", "(BC)165", "(BC)167", "(BC)208", "(BC)209", "(BC)238", "(BC)239", "(BC)247", "(BC)264", "(BC)275", "(O)PotOfGold", "(BC)MiniForge", "(BC)StatueOfTheDwarfKing", "(BC)StatueOfBlessings", "(BC)TextSign", "(O)464", "(O)463"
+        };
 
         private static readonly Dictionary<Tuple<string, object>, ProducerRule> RulesRepository = new();
-        private static readonly Dictionary<string, ProducerConfig> ConfigRepository = new()
-        {
-            {
-                "(BC)13", new ProducerConfig("Furnace",true){ProducerQualifiedItemId = "(BC)13"}
-            },
-            {
-                "(BC)17", new ProducerConfig("Loom",false,true){ProducerQualifiedItemId = "(BC)17"}
-            },
-            {
-                "(BC)114", new ProducerConfig("Charcoal Kiln",true){ProducerQualifiedItemId = "(BC)114"}
-            },
-            {
-                "(BC)12", new ProducerConfig("Keg", new Dictionary<StardewStats, string>(){{StardewStats.BeveragesMade,null}}){ProducerQualifiedItemId = "(BC)12"}
-            },
-            {
-                "(BC)15", new ProducerConfig("Preserves Jar", new Dictionary<StardewStats, string>(){{StardewStats.PreservesMade,null}}){ProducerQualifiedItemId = "(BC)15"}
-            },
-            {
-                "(BC)16", new ProducerConfig("Cheese Press", new Dictionary<StardewStats, string>(){{StardewStats.GoatCheeseMade, "426" },{StardewStats.CheeseMade, null } }){ProducerQualifiedItemId = "(BC)16"}
-            }
-        };
+        private static readonly Dictionary<string, ProducerConfig> ConfigRepository = new();
 
         private const string WarningNotBugPrefix = "This is just a Warning, don't report this as a bug. ";
 
@@ -464,7 +443,7 @@ namespace ProducerFrameworkMod.Controllers
             }
             else if (!Int32.TryParse(identifier, out int index))
             {
-                var pair = Game1.objectData.FirstOrDefault(o => o.Value.Name.Equals(identifier));
+                var pair = Game1.objectData.FirstOrDefault(o => identifier.Equals(o.Value.Name));
                 if (pair.Value != null)
                 {
                     itemId = ItemRegistry.type_object + pair.Key;

--- a/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
@@ -170,6 +170,7 @@ namespace ProducerFrameworkMod.Controllers
             producer.readyForHarvest.Value = false;
             producer.showNextIndex.Value = false;
             producer.MinutesUntilReady = -1;
+            producer.ResetParentSheetIndex();
 
             if (ProducerController.GetProducerConfig(producer.QualifiedItemId) is ProducerConfig producerConfig && producerConfig.LightSource?.AlwaysOn == true)
             {

--- a/ProducerFrameworkMod/ObjectOverrides.cs
+++ b/ProducerFrameworkMod/ObjectOverrides.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using StardewValley.Inventories;
 using StardewValley.ItemTypeDefinitions;
 using Object = StardewValley.Object;
+using StardewValley.GameData.Machines;
 #pragma warning disable IDE1006
 
 namespace ProducerFrameworkMod
@@ -396,17 +397,19 @@ namespace ProducerFrameworkMod
                     {
                         Game1.haltAfterCheck = false;
                     }
+                    bool check_for_reload = false;
                     Object previousObject = __instance.heldObject.Value;
-                    __instance.heldObject.Value = (Object)null;
                     if (who.IsLocalPlayer)
                     {
-                        if (!who.addItemToInventoryBool((Item)previousObject, false))
+                        __instance.heldObject.Value = (Object)null;
+                        if (!who.addItemToInventoryBool(previousObject))
                         {
                             __instance.heldObject.Value = previousObject;
                             Game1.showRedMessage(Game1.content.LoadString("Strings\\StringsFromCSFiles:Crop.cs.588"));
                             return __result = false;
                         }
                         Game1.playSound("coin");
+                        check_for_reload = true;
                         producerConfig.IncrementStats(previousObject);
                     }
                     ProducerRuleController.ClearProduction(__instance, who.currentLocation);
@@ -434,6 +437,23 @@ namespace ProducerFrameworkMod
                                 }
                             }
                         }
+                    }
+                    MachineData machineData = __instance.GetMachineData();
+                    if (machineData is { ExperienceGainOnHarvest: not null })
+                    {
+                        string[] expSplit = machineData.ExperienceGainOnHarvest.Split(' ');
+                        for (int i = 0; i < expSplit.Length; i += 2)
+                        {
+                            int skill = Farmer.getSkillNumberFromName(expSplit[i]);
+                            if (skill != -1 && ArgUtility.TryGetInt(expSplit, i + 1, out var amount, out var _))
+                            {
+                                who.gainExperience(skill, amount);
+                            }
+                        }
+                    }
+                    if (check_for_reload && producerConfig.NoInputStartMode == null)
+                    {
+                        __instance.AttemptAutoLoad(who);
                     }
                     return false;
                 }

--- a/ProducerFrameworkMod/manifest.json
+++ b/ProducerFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "Producer Framework Mod",
     "Author": "Digus",
-    "Version": "1.9.2",
+    "Version": "1.9.3",
     "Description": "Framework to add rules to produce objects or change the vanilla rules.",
     "UniqueID": "Digus.ProducerFrameworkMod",
     "EntryDll": "ProducerFrameworkMod.dll",


### PR DESCRIPTION
- Fix hopper behavior with vanilla and PFM machines.
- Remove PFM default configuration for some vanilla machines that would cause unexpected behavior.
- Fix mushroom box and log not giving experience as it should if some types of configuration were added to it.
- Mark some craftables with specific behavior as unsupported.
- Fix null reference error when an object with null name was loaded in the game.