### PR TITLE
Producer Framework Mod 1.9.4

### DIFF
--- a/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
+++ b/ProducerFrameworkMod/Controllers/ProducerRuleController.cs
@@ -132,6 +132,10 @@ namespace ProducerFrameworkMod.Controllers
                     {
                         producer.showNextIndex.Value = producerConfig.AlternateFrameProducing;
                     }
+                    else if (producer.GetMachineData() is { ShowNextIndexWhileWorking: true })
+                    {
+                        producer.showNextIndex.Value = true;
+                    }
 
                     if (producerRule.PlacingAnimation.HasValue && !noSoundAndAnimation)
                     {

--- a/ProducerFrameworkMod/ObjectOverrides.cs
+++ b/ProducerFrameworkMod/ObjectOverrides.cs
@@ -480,6 +480,10 @@ namespace ProducerFrameworkMod
                         {
                             if (producerConfig.NoInputStartMode == NoInputStartMode.DayUpdate || (producerConfig.NoInputStartMode == NoInputStartMode.Placement))
                             {
+                                if (__instance.GetMachineData().ClearContentsOvernightCondition == "TRUE")
+                                {
+                                    ProducerRuleController.ClearProduction(__instance, location);
+                                }
                                 if (__instance.heldObject.Value == null)
                                 {
                                     try

--- a/ProducerFrameworkMod/i18n/fr.json
+++ b/ProducerFrameworkMod/i18n/fr.json
@@ -1,0 +1,15 @@
+{
+    "Message.Requirement.Amount": "Nécessite {{amount}} {{objectName}}",
+    "Message.Requirement.Quality": "Nécessite une qualité différente",
+    "Message.Requirement.Fuel": "Nécessite un ingrédient manquant",
+    "Message.Requirement.Season": "Nécessite une saison différente",
+    "Message.Requirement.Weather": "Nécessite un temps différent",
+    "Message.Requirement.Location": "Nécessite un lieu différent",
+    "Message.Requirement.InputParent": "Nécessite un autre type de {{objectName}}",
+    "Message.Condition.Location": "Ne peut pas travailler ici",
+    "Message.Condition.Season": "Ne peut pas travailler cette saison",
+    "Object.Category.Meat": "Viande",
+    "Object.Category.MetalResources": "Ressources Métalliques",
+    "Object.Category.BuildingResources": "Ressources de construction",
+    "Object.Category.TappedTreeProduct": "Produit d’arbre"
+}

--- a/ProducerFrameworkMod/manifest.json
+++ b/ProducerFrameworkMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "Producer Framework Mod",
     "Author": "Digus",
-    "Version": "1.9.3",
+    "Version": "1.9.4",
     "Description": "Framework to add rules to produce objects or change the vanilla rules.",
     "UniqueID": "Digus.ProducerFrameworkMod",
     "EntryDll": "ProducerFrameworkMod.dll",


### PR DESCRIPTION
- Adds French i18n
- Fix machines vanilla machines with ShowNextIndexWhileWorking not show apropriate frame when loading a PFM rule, even if they had no ProducerConfig overriding it
- Fix vanilla machines with ClearContentOvernightCondition not cleating over night if they had a NoInputStartMode configuration.