### PR TITLE
Animal Husbandry Mod 2.6.11

### DIFF
--- a/ButcherMod/AnimalHusbandryModEntry.cs
+++ b/ButcherMod/AnimalHusbandryModEntry.cs
@@ -392,6 +392,7 @@ namespace AnimalHusbandryMod
             FarmerLoader.MoveOldPregnancyData();
             FarmerLoader.MoveOldAnimalStatusData();
             DataLoader.ToolsLoader.LoadMail();
+            DataLoader.RecipeLoader.LoadMails();
             DataLoader.AnimalData.FillLikedTreatsIds();
             EventsLoader.EventListener();
         }

--- a/ButcherMod/ModConfig.cs
+++ b/ButcherMod/ModConfig.cs
@@ -21,6 +21,8 @@ namespace AnimalHusbandryMod
         public bool DisableMeatFromDinosaur;
         public double PercentualAjustOnFriendshipInscreaseFromProfessions = 0.25;
         public bool DisableContestBonus;
+        public bool DisableFeedingBasketLetter;
+        public bool DisableInseminationSyringeLetter;
         public bool DisableMeatToolLetter;
         public bool DisableMeatButton;
         public bool DisableMeatInBlundle;

--- a/ButcherMod/animals/data/AnimalData.cs
+++ b/ButcherMod/animals/data/AnimalData.cs
@@ -101,10 +101,17 @@ namespace AnimalHusbandryMod.animals.data
             {
                 if (likedTreat is string s)
                 {
-                    KeyValuePair<string, ObjectData> pair = Game1.objectData.FirstOrDefault(o => o.Value.Name.Equals(s));
-                    if (pair.Value != null)
+                    if (ItemRegistry.Exists(ItemRegistry.type_object + s))
                     {
-                        treatItem.LikedTreatsId.Add(pair.Key);
+                        treatItem.LikedTreatsId.Add(s);
+                    }
+                    else
+                    {
+                        KeyValuePair<string, ObjectData> pair = Game1.objectData.FirstOrDefault(o => s.Equals(o.Value.Name));
+                        if (pair.Value != null)
+                        {
+                            treatItem.LikedTreatsId.Add(pair.Key);
+                        }
                     }
                 }
                 else if (likedTreat is long l)

--- a/ButcherMod/common/DataLoader.cs
+++ b/ButcherMod/common/DataLoader.cs
@@ -419,66 +419,69 @@ namespace AnimalHusbandryMod.common
         private void CreateConfigMenu(IManifest manifest)
         {
             GenericModConfigMenuApi api = Helper.ModRegistry.GetApi<GenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
-            if (api != null)
-            {
-                api.Register(manifest, () => DataLoader.ModConfig = new ModConfig(), () => Helper.WriteConfig(DataLoader.ModConfig));
+            if (api == null) return;
 
-                api.AddSectionTitle(manifest, () => "Main Features:", () => "Properties to disable the mod main features.");
+            api.Register(manifest, () => DataLoader.ModConfig = new ModConfig(), () => Helper.WriteConfig(DataLoader.ModConfig));
 
-                api.RegisterSimpleOption(manifest, "Disable Meat", "Disable all features related to meat. Meat Cleaver/Wand will not be delivered , and if already owned, will not work. Meat items and meat dishes will not be loaded. Any item still on the inventory will be bugged. You should sell/trash all of them before disabling meat. Meat Friday will not show on TV. You will not receive any more meat recipe letter from the villagers. Learned recipes will still be known, but will not show on the cooking menu. If re-enabled, they will show again. Restart the game after changing this.", () => DataLoader.ModConfig.DisableMeat, (bool val) => DataLoader.ModConfig.DisableMeat = val);
+            api.AddSectionTitle(manifest, () => "Main Features:", () => "Properties to disable the mod main features.");
+
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMeat, (bool val) => DataLoader.ModConfig.DisableMeat = val, () => "Disable Meat", () => "Disable all features related to meat. Meat Cleaver/Wand will not be delivered , and if already owned, will not work. Meat items and meat dishes will not be loaded. Any item still on the inventory will be bugged. You should sell/trash all of them before disabling meat. Meat Friday will not show on TV. You will not receive any more meat recipe letter from the villagers. Learned recipes will still be known, but will not show on the cooking menu. If re-enabled, they will show again. Restart the game after changing this.");
                 
-                api.RegisterSimpleOption(manifest, "Disable Pregnancy", "Disable all features related to pregnancy. Syringe will not be delivered, and if already owned, it will not work. Pregnancy status will not update but will not reset. Animals that were pregnant will be with random pregnancy disabled unless changed. If re-enabled, everything will resume as it was before. Restart the game after changing this.", () => DataLoader.ModConfig.DisablePregnancy, (bool val) => DataLoader.ModConfig.DisablePregnancy = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisablePregnancy, (bool val) => DataLoader.ModConfig.DisablePregnancy = val, () => "Disable Pregnancy", () => "Disable all features related to pregnancy. Syringe will not be delivered, and if already owned, it will not work. Pregnancy status will not update but will not reset. Animals that were pregnant will be with random pregnancy disabled unless changed. If re-enabled, everything will resume as it was before. Restart the game after changing this.");
                 
-                api.RegisterSimpleOption(manifest, "Disable Treats", "Disable all features related to treats. The basket will not be delivered, and if already owned, it will not work. Treat status will update while the treat feature is disable. Animals that were feed treats before will be able to eat again if the appropriate amount of days has passed when the mod was disabled. Restart the game after changing this.", () => DataLoader.ModConfig.DisableTreats, (bool val) => DataLoader.ModConfig.DisableTreats = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableTreats, (bool val) => DataLoader.ModConfig.DisableTreats = val, () => "Disable Treats", () => "Disable all features related to treats. The basket will not be delivered, and if already owned, it will not work. Treat status will update while the treat feature is disable. Animals that were feed treats before will be able to eat again if the appropriate amount of days has passed when the mod was disabled. Restart the game after changing this.");
                 
-                api.RegisterSimpleOption(manifest, "Disable Animal Contest", "Disable all features related to the animal contest. You won't receive any more participant ribbons. Bonus from previous winners will still apply though. Restart the game after changing this.", () => DataLoader.ModConfig.DisableAnimalContest, (bool val) => DataLoader.ModConfig.DisableAnimalContest = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableAnimalContest, (bool val) => DataLoader.ModConfig.DisableAnimalContest = val, () => "Disable Animal Contest", () => "Disable all features related to the animal contest. You won't receive any more participant ribbons. Bonus from previous winners will still apply though. Restart the game after changing this.");
 
-                api.AddSectionTitle(manifest, () => "Meat Properties:", () => "Properties to configure the meat feature.");
+            api.AddSectionTitle(manifest, () => "Meat Properties:", () => "Properties to configure the meat feature.");
 
-                api.RegisterSimpleOption(manifest, "Softmode", "Enable the Softmode. When enabled the Meat Cleaver is replaced with the Meat Want. They work the same, but sound, text and effects are changed to resemble magic. Restart the game after changing this.", () => DataLoader.ModConfig.Softmode, (bool val) => DataLoader.ModConfig.Softmode = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.Softmode, (bool val) => DataLoader.ModConfig.Softmode = val, () => "Softmode", () => "Enable the Softmode. When enabled the Meat Cleaver is replaced with the Meat Want. They work the same, but sound, text and effects are changed to resemble magic. Restart the game after changing this.");
 
-                api.RegisterSimpleOption(manifest, "Disable Rancher Affect Meat", "Disable the patch that make Rancher Profession work on meat items.", () => DataLoader.ModConfig.DisableRancherMeatPriceAjust, (bool val) => DataLoader.ModConfig.DisableRancherMeatPriceAjust = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableRancherMeatPriceAjust, (bool val) => DataLoader.ModConfig.DisableRancherMeatPriceAjust = val, () => "Disable Rancher Affect Meat", () => "Disable the patch that make Rancher Profession work on meat items.");
 
-                api.RegisterSimpleOption(manifest, "Disable Meat In Bundle", "Disable the addition of meat to the Animal Bundle in the Community Center. Needs to start a new game so it can take effect.", () => DataLoader.ModConfig.DisableMeatInBlundle, (bool val) => { DataLoader.ModConfig.DisableMeatInBlundle = val; Helper.GameContent.InvalidateCache("Data\\Bundles"); });
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMeatInBlundle, (bool val) => { DataLoader.ModConfig.DisableMeatInBlundle = val; Helper.GameContent.InvalidateCache("Data\\Bundles"); }, () => "Disable Meat In Bundle", () => "Disable the addition of meat to the Animal Bundle in the Community Center. Needs to start a new game so it can take effect.");
 
-                api.RegisterSimpleOption(manifest, "Disable Meat From Dinosaur", "Disable dinosaur giving a random kind of meat.", () => DataLoader.ModConfig.DisableMeatFromDinosaur, (bool val) => DataLoader.ModConfig.DisableMeatFromDinosaur = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMeatFromDinosaur, (bool val) => DataLoader.ModConfig.DisableMeatFromDinosaur = val, () => "Disable Meat From Dinosaur", () => "Disable dinosaur giving a random kind of meat.");
 
-                api.RegisterSimpleOption(manifest, "Disable Meat Tool Letter", "Disable the sending of the meat cleaver or the meat wand. Meat will only be able to be obtained through the meat button.", () => DataLoader.ModConfig.DisableMeatToolLetter, (bool val) => DataLoader.ModConfig.DisableMeatToolLetter = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMeatToolLetter, (bool val) => DataLoader.ModConfig.DisableMeatToolLetter = val, () => "Disable Meat Tool Letter", () => "Disable the sending of the meat cleaver or the meat wand. Meat will only be able to be obtained through the meat button.");
 
-                api.RegisterSimpleOption(manifest, "Disable Meat Button", "Disable the meat button showing in the animal query menu. Meat will only be able to be obtained using the tools.", () => DataLoader.ModConfig.DisableMeatButton, (bool val) => DataLoader.ModConfig.DisableMeatButton = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMeatButton, (bool val) => DataLoader.ModConfig.DisableMeatButton = val, () => "Disable Meat Button", () => "Disable the meat button showing in the animal query menu. Meat will only be able to be obtained using the tools.");
 
-                api.RegisterSimpleOption(manifest, "Add Meat Tool Key", "Set a keyboard key to directly add the Meat Cleaver/Want to your inventory.", () => DataLoader.ModConfig.AddMeatCleaverToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddMeatCleaverToInventoryKey = val == SButton.None ? (SButton?)null : val);
+            api.AddKeybind(manifest, () => DataLoader.ModConfig.AddMeatCleaverToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddMeatCleaverToInventoryKey = val == SButton.None ? (SButton?)null : val, () => "Add Meat Tool Key", () => "Set a keyboard key to directly add the Meat Cleaver/Want to your inventory.");
 
-                api.AddSectionTitle(manifest, () => "Pregnancy Properties:", () => "Properties to configure the insemination feature.");
+            api.AddSectionTitle(manifest, () => "Pregnancy Properties:", () => "Properties to configure the insemination feature.");
 
-                api.RegisterSimpleOption(manifest, "Disable Full Build Notif.", "Disable notifications for when an animals can't give birth because their building is full.", () => DataLoader.ModConfig.DisableFullBuildingForBirthNotification, (bool val) => DataLoader.ModConfig.DisableFullBuildingForBirthNotification = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableFullBuildingForBirthNotification, (bool val) => DataLoader.ModConfig.DisableFullBuildingForBirthNotification = val, () => "Disable Full Build Notif.", () => "Disable notifications for when an animals can't give birth because their building is full.");
                 
-                api.RegisterSimpleOption(manifest, "Disable Birth Notif.", "Disable notifications for when an animal will give birth tomorrow.", () => DataLoader.ModConfig.DisableTomorrowBirthNotification, (bool val) => DataLoader.ModConfig.DisableTomorrowBirthNotification = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableTomorrowBirthNotification, (bool val) => DataLoader.ModConfig.DisableTomorrowBirthNotification = val, () => "Disable Birth Notif.", () => "Disable notifications for when an animal will give birth tomorrow.");
 
-                api.RegisterSimpleOption(manifest, "Add Insemination Syringe Key", "Set a keyboard key to directly add the Insemination Syringe to your inventory.", () => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey = val == SButton.None ? (SButton?)null : val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableInseminationSyringeLetter, (bool val) => DataLoader.ModConfig.DisableInseminationSyringeLetter = val, () => "Disable Insemination Letter", () => "Disable the sending of the Insemination Syringe. You will need to get the syringe another way.");
 
-                api.AddSectionTitle(manifest, () => "Treats Properties:", () => "Properties to configure the treats feature.");
+            api.AddKeybind(manifest, () => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddInseminationSyringeToInventoryKey = val == SButton.None ? (SButton?)null : val, () => "Add Insemination Syringe Key", () => "Set a keyboard key to directly add the Insemination Syringe to your inventory.");
 
-                api.RegisterSimpleOption(manifest, "Disable Friendship Increase", "Disable animal friendship being increased when given a treat.", () => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats, (bool val) => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats = val);
+            api.AddSectionTitle(manifest, () => "Treats Properties:", () => "Properties to configure the treats feature.");
 
-                api.RegisterSimpleOption(manifest, "Disable Mood Increase", "Disable animal mood being set to max when given a treat.", () => DataLoader.ModConfig.DisableMoodInscreseWithTreats, (bool val) => DataLoader.ModConfig.DisableMoodInscreseWithTreats = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats, (bool val) => DataLoader.ModConfig.DisableFriendshipInscreseWithTreats = val, () => "Disable Friendship Increase", () => "Disable animal friendship being increased when given a treat.");
 
-                api.RegisterSimpleOption(manifest, "Enable Treats Count As Feed", "Enable animal feed status being set to max when given a treat.", () => DataLoader.ModConfig.EnableTreatsCountAsAnimalFeed, (bool val) => DataLoader.ModConfig.EnableTreatsCountAsAnimalFeed = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableMoodInscreseWithTreats, (bool val) => DataLoader.ModConfig.DisableMoodInscreseWithTreats = val, () => "Disable Mood Increase", () => "Disable animal mood being set to max when given a treat.");
 
-                api.RegisterSimpleOption(manifest, "Professions Adjust", "Change the percentage adjust for friendship increase when giving treats when you have the coopmaster or shepherd professions. 0.25 means 25% more than usual.", () => (float)DataLoader.ModConfig.PercentualAjustOnFriendshipInscreaseFromProfessions, (float val) => DataLoader.ModConfig.PercentualAjustOnFriendshipInscreaseFromProfessions = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.EnableTreatsCountAsAnimalFeed, (bool val) => DataLoader.ModConfig.EnableTreatsCountAsAnimalFeed = val, () => "Enable Treats Count As Feed", () => "Enable animal feed status being set to max when given a treat.");
 
-                api.RegisterSimpleOption(manifest, "Add Feeding Basket Key", "Set a keyboard key to directly add the Feeding Basket to your inventory.", () => DataLoader.ModConfig.AddFeedingBasketToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddFeedingBasketToInventoryKey = val == SButton.None ? (SButton?) null : val);
+            api.AddNumberOption(manifest, () => (float)DataLoader.ModConfig.PercentualAjustOnFriendshipInscreaseFromProfessions, (float val) => DataLoader.ModConfig.PercentualAjustOnFriendshipInscreaseFromProfessions = val, () => "Professions Adjust", () => "Change the percentage adjust for friendship increase when giving treats when you have the coopmaster or shepherd professions. 0.25 means 25% more than usual.");
 
-                api.AddSectionTitle(manifest, () => "Animal Contest Properties:", () => "Properties to configure the animal contest feature.");
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableFeedingBasketLetter, (bool val) => DataLoader.ModConfig.DisableFeedingBasketLetter = val, () => "Disable Feeding Basket Letter", () => "Disable the sending of the Feeding Basket. You will need to get the basket another way.");
 
-                api.RegisterSimpleOption(manifest, "Disable Contest Bonus", "Disable the fertility and the production bonuses from the contest. If enabled again, all winners will receive the bonus again, no matter if the bonus was disabled when they won.", () => DataLoader.ModConfig.DisableContestBonus, (bool val) => DataLoader.ModConfig.DisableContestBonus = val);
+            api.AddKeybind(manifest, () => DataLoader.ModConfig.AddFeedingBasketToInventoryKey ?? SButton.None, (SButton val) => DataLoader.ModConfig.AddFeedingBasketToInventoryKey = val == SButton.None ? (SButton?)null : val, () => "Add Feeding Basket Key", () => "Set a keyboard key to directly add the Feeding Basket to your inventory.");
 
-                api.AddSectionTitle(manifest, () => "Misc. Properties:", () => "Miscellaneous Properties.");
+            api.AddSectionTitle(manifest, () => "Animal Contest Properties:", () => "Properties to configure the animal contest feature.");
 
-                api.RegisterSimpleOption(manifest, "Force Draw Attachment", "Force the patch that draw the hover menu for the feeding basket and insemination syringe on any OS. Restart the game after changing this.", () => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS, (bool val) => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS = val);
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableContestBonus, (bool val) => DataLoader.ModConfig.DisableContestBonus = val, () => "Disable Contest Bonus", () => "Disable the fertility and the production bonuses from the contest. If enabled again, all winners will receive the bonus again, no matter if the bonus was disabled when they won.");
 
-                api.RegisterSimpleOption(manifest, "Disable TV Channels", "Disable all TV channels added by this mod.", () => DataLoader.ModConfig.DisableTvChannels, (bool val) => DataLoader.ModConfig.DisableTvChannels = val);
-            }
+            api.AddSectionTitle(manifest, () => "Misc. Properties:", () => "Miscellaneous Properties.");
+
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS, (bool val) => DataLoader.ModConfig.ForceDrawAttachmentOnAnyOS = val, () => "Force Draw Attachment", () => "Force the patch that draw the hover menu for the feeding basket and insemination syringe on any OS. Restart the game after changing this.");
+
+            api.AddBoolOption(manifest, () => DataLoader.ModConfig.DisableTvChannels, (bool val) => DataLoader.ModConfig.DisableTvChannels = val, () => "Disable TV Channels", () => "Disable all TV channels added by this mod.");
         }
         enum Taste {
             Love = 1,

--- a/ButcherMod/integrations/GenericModConfigMenuApi.cs
+++ b/ButcherMod/integrations/GenericModConfigMenuApi.cs
@@ -25,8 +25,36 @@ namespace AnimalHusbandryMod.integrations
         /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
         void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
 
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
-        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
+        /// <summary>Add a boolean option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
+        /// <summary>Add a float option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<float> getValue, Action<float> setValue, Func<string> name, Func<string> tooltip = null, float? min = null, float? max = null, float? interval = null, Func<float, string> formatValue = null, string fieldId = null);
+
+        /// <summary>Add a key binding at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddKeybind(IManifest mod, Func<SButton> getValue, Action<SButton> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
     }
 }

--- a/ButcherMod/manifest.json
+++ b/ButcherMod/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "Animal Husbandry Mod",
    "Author": "Digus",
-   "Version": "2.6.10",
+   "Version": "2.6.11",
    "Description": "Adds features related to animal husbandry.",
    "UniqueID": "DIGUS.ANIMALHUSBANDRYMOD",
    "EntryDll": "AnimalHusbandryMod.dll",

--- a/ButcherMod/meats/MeatExtension.cs
+++ b/ButcherMod/meats/MeatExtension.cs
@@ -34,7 +34,8 @@ namespace AnimalHusbandryMod.meats
                 DisplayName = i18n.Get($"Meat.{value}.Name"),
                 Description = i18n.Get($"Meat.{value}.Description"),
                 Category = -14,
-                Type = "Basic"
+                Type = "Basic",
+                ContextTags = new List<string>() { "meat_item" }
             };
         }        
     }

--- a/ButcherMod/tools/ToolsLoader.cs
+++ b/ButcherMod/tools/ToolsLoader.cs
@@ -242,7 +242,7 @@ namespace AnimalHusbandryMod.tools
             List<string> validBuildingsForInsemination = new List<string>(new string[] { "Deluxe Barn", "Big Barn", "Deluxe Coop" });
             bool InseminationSyringeCondition(Letter l)
             {
-                if (DataLoader.ModConfig.DisablePregnancy) return false;
+                if (DataLoader.ModConfig.DisablePregnancy || DataLoader.ModConfig.DisableInseminationSyringeLetter) return false;
                 bool hasAnimalInValidBuildings = Game1.locations.Any((location) =>
                 {
                     if (location is Farm farm)
@@ -260,12 +260,12 @@ namespace AnimalHusbandryMod.tools
 
             bool FeedingBasketCondition(Letter l)
             {
-                return !DataLoader.ModConfig.DisableTreats && !Game1.player.mailReceived.Contains(l.Id) && Game1.player.getFriendshipHeartLevelForNPC("Marnie") >= 2 && (Game1.player.hasPet() || HasAnimal());
+                return !DataLoader.ModConfig.DisableTreats && !DataLoader.ModConfig.DisableFeedingBasketLetter && !Game1.player.mailReceived.Contains(l.Id) && Game1.player.getFriendshipHeartLevelForNPC("Marnie") >= 2 && (Game1.player.hasPet() || HasAnimal());
             }
 
             bool FeedingBasketRedeliveryCondition(Letter l)
             {
-                return !DataLoader.ModConfig.DisableTreats && Game1.player.mailReceived.Contains("feedingBasket") && !ItemUtility.HasModdedItem(FeedingBasketOverrides.FeedingBasketKey) && Game1.player.getFriendshipHeartLevelForNPC("Marnie") >= 6;
+                return !DataLoader.ModConfig.DisableTreats && !DataLoader.ModConfig.DisableFeedingBasketLetter && Game1.player.mailReceived.Contains("feedingBasket") && !ItemUtility.HasModdedItem(FeedingBasketOverrides.FeedingBasketKey) && Game1.player.getFriendshipHeartLevelForNPC("Marnie") >= 6;
             }
 
             Letter meatCleaverLetter = new Letter("meatCleaver", meatCleaverText, MeatCleaverCondition, (l) => { if (!Game1.player.mailReceived.Contains(l.Id)) Game1.player.mailReceived.Add(l.Id); })


### PR DESCRIPTION
- Fix recipe mails not being translated.
- Two new properties to disable the Insemination Syringe and Feeding Basket Letters.
- Fix null reference error when looking for treats and there is an object with null name loaded in the game.
- Update the mod to use GMCM new API.
- Adding the "meat_item" context tag to all meat items.