### PR TITLE
Advanced Weather Forecast Mod 1.0.0

### DIFF
--- a/AdvancedWeatherForecastMod/AdvancedWeatherForecastMod.csproj
+++ b/AdvancedWeatherForecastMod/AdvancedWeatherForecastMod.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>G:\Program Files (x86)\Steam\steamapps\common\Stardew Valley\smapi-internal\0Harmony.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/AdvancedWeatherForecastMod/AdvancedWeatherForecastModEntry.cs
+++ b/AdvancedWeatherForecastMod/AdvancedWeatherForecastModEntry.cs
@@ -1,0 +1,93 @@
+﻿using AdvancedWeatherForecastMod.api;
+using AdvancedWeatherForecastMod.overrides;
+using HarmonyLib;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley;
+using StardewValley.Menus;
+using StardewValley.Network;
+using DataLoader = AdvancedWeatherForecastMod.common.DataLoader;
+
+namespace AdvancedWeatherForecastMod
+{
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
+    public class AdvancedWeatherForecastModEntry : Mod
+    {
+        public static IModHelper ModHelper;
+        public static IMonitor ModMonitor;
+        public static IManifest Manifest;
+
+        /// <summary>
+        /// The mod entry point, called after the mod is first loaded.
+        /// Here it loads the custom event handlers for the start of the day, after load and after returning to the title screen.
+        /// </summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
+        public override void Entry(IModHelper helper)
+        {
+            ModHelper = helper;
+            ModMonitor = Monitor;
+            Manifest = ModManifest;
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+            helper.Events.GameLoop.Saving += OnSaving;
+        }
+
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves). All mods are loaded and initialized at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object? sender, GameLaunchedEventArgs e)
+        {
+            new DataLoader(ModHelper, ModManifest);
+
+            var harmony = new Harmony("Digus.AdvancedWeatherForecastMod");
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(LocationWeather), nameof(LocationWeather.UpdateDailyWeather)),
+                prefix: new HarmonyMethod(typeof(LocationWeatherOverrides),
+                    nameof(LocationWeatherOverrides.UpdateDailyWeather_Prefix)),
+                postfix: new HarmonyMethod(typeof(LocationWeatherOverrides),
+                    nameof(LocationWeatherOverrides.UpdateDailyWeather_Postfix))
+            );
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Game1), nameof(Game1.UpdateWeatherForNewDay)),
+                postfix: new HarmonyMethod(typeof(LocationWeatherOverrides),
+                    nameof(LocationWeatherOverrides.UpdateWeatherForNewDay_Postfix))
+            );
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Billboard), nameof(Billboard.draw), new[] { typeof(SpriteBatch) }),
+                postfix: new HarmonyMethod(typeof(BillboardOverrides), nameof(BillboardOverrides.draw))
+            );
+
+            ModHelper.ConsoleCommands.Add("world_clear_weatherforecastdata", "Clear weather forecast for all locations", (c, a) => WeatherDataRepository.ClearWeatherData());
+            ModHelper.ConsoleCommands.Add("world_calculate_weatherforecast", "Calculate weather forecast for all locations. Won't override data, needs to clear first.", (c, a) => WeatherForecastController.CalculateAllForecast());
+
+        }
+
+        /// <summary>Raised after the player loads a save slot and the world is initialized.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnSaveLoaded(object? sender, SaveLoadedEventArgs e)
+        {
+            WeatherDataRepository.ClearWeatherDataCache();
+            WeatherForecastController.CalculateAllForecast();
+        }
+
+        /// <summary>Raised before the game is saved.</summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnSaving(object? sender, SavingEventArgs e)
+        {
+            WeatherDataRepository.SaveWeatherData();
+        }
+
+        /// <inheritdoc />
+        public override object? GetApi()
+        {
+            return new AdvancedWeatherForecastModApi();
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/WeatherDataRepository.cs
+++ b/AdvancedWeatherForecastMod/WeatherDataRepository.cs
@@ -1,0 +1,51 @@
+﻿using StardewValley.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Threading.Tasks;
+using StardewValley;
+
+namespace AdvancedWeatherForecastMod
+{
+    internal class WeatherDataRepository
+    {
+        private static Dictionary<string, Dictionary<long, string>>? _weatherData = null;
+
+        public static void ClearWeatherData()
+        {
+            foreach (var weatherDataValue in _weatherData.Values)
+            {
+                weatherDataValue.Clear();
+            }
+
+            AdvancedWeatherForecastModEntry.ModHelper.Data.WriteSaveData<Dictionary<string, Dictionary<long, string>>>("WeatherData", _weatherData);
+        }
+
+        public static void ClearWeatherDataCache()
+        {
+            _weatherData = null;
+        }
+
+        public static Dictionary<string,Dictionary<long, string>> GetWeatherData()
+        {
+            return _weatherData = _weatherData ?? AdvancedWeatherForecastModEntry.ModHelper.Data.ReadSaveData<Dictionary<string, Dictionary<long, string>>>("WeatherData") ?? new Dictionary<string, Dictionary<long, string>>();
+        }
+        
+        public static void SaveWeatherData()
+        {
+            AdvancedWeatherForecastModEntry.ModHelper.Data.WriteSaveData<Dictionary<string, Dictionary<long, string>>>("WeatherData", _weatherData);
+        }
+
+        public static void ClearPastWeatherData()
+        {
+            if (_weatherData == null) return;
+            foreach (var locationWeatherData in _weatherData.Values)
+            {
+                locationWeatherData.RemoveWhere(i => i.Key <= Game1.Date.TotalDays);
+            }
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/WeatherForecastController.cs
+++ b/AdvancedWeatherForecastMod/WeatherForecastController.cs
@@ -1,0 +1,111 @@
+﻿using StardewValley.GameData.LocationContexts;
+using StardewValley.Network;
+using StardewValley;
+using System.Collections.Generic;
+using Force.DeepCloner;
+using StardewModdingAPI.Utilities;
+using DataLoader = AdvancedWeatherForecastMod.common.DataLoader;
+
+namespace AdvancedWeatherForecastMod
+{
+    internal class WeatherForecastController
+    {
+        private static int _futureDay = 0;
+
+        public static bool IsFutureDay()
+        {
+            return Game1.stats.DaysPlayed > 0 && _futureDay > 0;
+        }
+
+        public static void AddDateFutureDay()
+        {
+            Game1.stats.DaysPlayed = (uint)(Game1.stats.DaysPlayed + _futureDay);
+            var futureDate = SDate.From(Game1.Date).AddDays(_futureDay);
+            Game1.dayOfMonth = futureDate.Day;
+            Game1.season = futureDate.Season;
+            Game1.year = futureDate.Year;
+        }
+
+        public static void SubtractDateFutureDay()
+        {
+            Game1.stats.DaysPlayed = (uint)(Game1.stats.DaysPlayed - _futureDay);
+            var originalDate = SDate.From(Game1.Date).AddDays(-1 * _futureDay);
+            Game1.dayOfMonth = originalDate.Day;
+            Game1.season = originalDate.Season;
+            Game1.year = originalDate.Year;
+        }
+
+        public static void CalculateAllForecast()
+        {
+            CalculateWeatherForecast(1);
+        }
+
+        public static void CalculateWeatherForNewDay()
+        {
+            CalculateWeatherForecast(DataLoader.ModConfig.DaysInAdvanceForecast - 1);
+        }
+        
+        private static void CalculateWeatherForecast( int startAt)
+        {
+            var weatherData = WeatherDataRepository.GetWeatherData();
+
+            foreach (KeyValuePair<string, LocationContextData> locationContextDataPair in Game1.locationContextData)
+            {
+                var location = locationContextDataPair.Key;
+                var contextData = locationContextDataPair.Value;
+                if (!weatherData.ContainsKey(location)) weatherData.Add(location, new Dictionary<long, string>());
+                var locationWeatherData = weatherData[location];
+                for (var i = startAt; i < DataLoader.ModConfig.DaysInAdvanceForecast; i++)
+                {
+                    _futureDay = i;
+                    var dateTotalDays = Game1.Date.TotalDays + i + 1;
+                    if (!locationWeatherData.ContainsKey(dateTotalDays) && contextData.CopyWeatherFromLocation == null)
+                    {
+                        var locationWeather = new LocationWeather();
+                        locationWeather.UpdateDailyWeather(location, contextData, Game1.random);
+                        locationWeatherData[dateTotalDays] = locationWeather.WeatherForTomorrow;
+                    }
+                }
+            }
+            _futureDay = 0;
+            CheckWeatherDataToCopy(weatherData);
+        }
+
+        public static void UpdateWeatherForTomorrow()
+        {
+            var weatherData = WeatherDataRepository.GetWeatherData();
+            foreach (var location in Game1.locationContextData.Keys)
+            {
+                if (!weatherData[location].ContainsKey(Game1.Date.TotalDays + 1)) continue;
+                var weatherForLocation = Game1.netWorldState.Value.GetWeatherForLocation(location);
+                if (weatherForLocation.WeatherForTomorrow is Game1.weather_festival or Game1.weather_wedding) weatherData[location][Game1.Date.TotalDays + 1] = weatherForLocation.WeatherForTomorrow;
+                weatherForLocation.WeatherForTomorrow = weatherData[location][Game1.Date.TotalDays + 1];
+            }
+            Game1.weatherForTomorrow = Game1.netWorldState.Value.GetWeatherForLocation("Default").WeatherForTomorrow;
+        }
+
+        public static void UpdateLocationWeatherData(LocationWeather locationWeather, string locationContextId)
+        {
+            var weatherData = WeatherDataRepository.GetWeatherData();
+            var locationWeatherData = weatherData[locationContextId];
+            locationWeatherData[Game1.Date.TotalDays + 1] = locationWeather.WeatherForTomorrow;
+        }
+
+        public static void ApplyWeatherModificationsForDateTomorrow(LocationWeather locationWeather)
+        {
+            locationWeather.WeatherForTomorrow = Game1.getWeatherModificationsForDate(SDate.FromDaysSinceStart(Game1.Date.TotalDays + 2).ToWorldDate(), locationWeather.WeatherForTomorrow);
+        }
+
+        private static void CheckWeatherDataToCopy(Dictionary<string, Dictionary<long, string>> weatherData)
+        {
+            foreach (KeyValuePair<string, LocationContextData> pair in Game1.locationContextData)
+            {
+                var contextToCopy = pair.Value.CopyWeatherFromLocation;
+                if (contextToCopy != null)
+                {
+                    weatherData[pair.Key] = weatherData[contextToCopy].DeepClone();
+                }
+            }
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/api/AdvancedWeatherForecastModApi.cs
+++ b/AdvancedWeatherForecastMod/api/AdvancedWeatherForecastModApi.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Force.DeepCloner;
+using StardewModdingAPI.Utilities;
+using xTile.Dimensions;
+
+namespace AdvancedWeatherForecastMod.api
+{
+    public class AdvancedWeatherForecastModApi : IAdvancedWeatherForecastModApi
+    {
+        public Dictionary<string, Dictionary<long, string>> GetWeatherForecastData()
+        {
+            return WeatherDataRepository.GetWeatherData().DeepClone();
+        }
+
+        public string? GetWeatherForecast(string locationContextId, SDate date)
+        {
+            string? weather = null;
+            if (WeatherDataRepository.GetWeatherData().TryGetValue(locationContextId, out var locationWeatherData))
+            {
+                locationWeatherData.TryGetValue(date.DaysSinceStart, out weather);
+            }
+            return weather;
+        }
+
+        /// <summary>
+        /// Set the weather for a particular location and date.
+        /// </summary>
+        /// <param name="locationContextId">The context id of a location</param>
+        /// <param name="date">The smapi date</param>
+        /// <param name="weather">The weather identification string</param>
+        public void SetWeatherForecast(string locationContextId, SDate date, string weather)
+        {
+            var weatherData = WeatherDataRepository.GetWeatherData();
+            if (!weatherData.ContainsKey(locationContextId)) weatherData.Add(locationContextId, new Dictionary<long, string>());
+            weatherData[locationContextId][date.DaysSinceStart] = weather;
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/api/IAdvancedWeatherForecastModApi.cs
+++ b/AdvancedWeatherForecastMod/api/IAdvancedWeatherForecastModApi.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StardewModdingAPI.Utilities;
+
+namespace AdvancedWeatherForecastMod.api
+{
+    public interface IAdvancedWeatherForecastModApi
+    {
+        /// <summary>
+        /// Get a copy of weather forecast data. Changing this dictionary does not alter the weather.
+        /// The key to the dictionary is the locationContextId, that is different from the location name.
+        /// The value of the dictionary is another dictionary that the key is the date number of days since the start of the game and the value is the weather string identification.
+        /// 
+        /// </summary>
+        /// <returns>The dictionary containing the weather data for all locations.</returns>
+        public Dictionary<string,Dictionary<long,string>> GetWeatherForecastData();
+        /// <summary>
+        /// Get the weather for a particular location and date.
+        /// </summary>
+        /// <param name="locationContextId">The context id of a location</param>
+        /// <param name="date">The smapi date</param>
+        /// <returns>The weather identification string, null if there is no weather for that location and date</returns>
+        public string? GetWeatherForecast(string locationContextId, SDate date);
+        /// <summary>
+        /// Set the weather for a particular location and date.
+        /// </summary>
+        /// <param name="locationContextId">The context id of a location</param>
+        /// <param name="date">The smapi date</param>
+        /// <param name="weather">The weather identification string</param>
+        public void SetWeatherForecast(string locationContextId, SDate date, string weather);
+    }
+}

--- a/AdvancedWeatherForecastMod/common/DataLoader.cs
+++ b/AdvancedWeatherForecastMod/common/DataLoader.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AdvancedWeatherForecastMod.integrations;
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace AdvancedWeatherForecastMod.common
+{
+    public class DataLoader
+    {
+        public static IModHelper Helper;
+        public static ITranslationHelper I18N;
+        public static ModConfig ModConfig;
+
+        public DataLoader(IModHelper helper, IManifest manifest)
+        {
+            Helper = helper;
+            I18N = helper.Translation;
+            ModConfig = helper.ReadConfig<ModConfig>();
+
+            LoadMail();
+
+            CreateConfigMenu(manifest);
+        }
+
+        internal static void LoadMail()
+        {
+            IMailFrameworkModApi mailFrameworkModApi = Helper.ModRegistry.GetApi<IMailFrameworkModApi>("DIGUS.MailFrameworkMod");
+
+            mailFrameworkModApi?.RegisterLetter(
+                new ApiLetter
+                {
+                    Id = "AdvancedWeatherForecastLetter"
+                    ,
+                    Text = "AdvancedWeatherForecast.Letter"
+                    ,
+                    Title = "AdvancedWeatherForecast.Letter.Title"
+                    ,
+                    I18N = I18N
+                }, (l) => !Game1.player.mailReceived.Contains(l.Id)
+                , (l) => Game1.player.mailReceived.Add(l.Id)
+            );
+        }
+
+        private void CreateConfigMenu(IManifest manifest)
+        {
+            GenericModConfigMenuApi? api = Helper.ModRegistry.GetApi<GenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
+            if (api == null) return;
+
+            api.Register(manifest, () => ModConfig = new ModConfig(), () => Helper.WriteConfig(ModConfig));
+
+            api.AddNumberOption(manifest, () => ModConfig.DaysInAdvanceForecast, (val) => ModConfig.DaysInAdvanceForecast = val, () => "Days in advance forecast", () => "How many days in advance you can know the weather forecast. You can set a number from 1 to 27.", 1, 27);
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/common/ModConfig.cs
+++ b/AdvancedWeatherForecastMod/common/ModConfig.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdvancedWeatherForecastMod.common
+{
+    public class ModConfig
+    {
+        public int DaysInAdvanceForecast = 7;
+    }
+}

--- a/AdvancedWeatherForecastMod/i18n/default.json
+++ b/AdvancedWeatherForecastMod/i18n/default.json
@@ -1,0 +1,4 @@
+﻿{
+    "AdvancedWeatherForecast.Letter": "Dear @,^^In order to better study the plants and animals of the valley, I have recently installed an advanced weather forecasting system in my lab.^I thought that information might be useful for you too, so from now on I shall be updating the town's calendar with the forecast of the following days.^That information should also reflect on your personal calendars.^   -Demetrius",
+    "AdvancedWeatherForecast.Letter.Title": "Demetrius' Advanced Weather Forecast"
+}

--- a/AdvancedWeatherForecastMod/i18n/pt.json
+++ b/AdvancedWeatherForecastMod/i18n/pt.json
@@ -1,0 +1,4 @@
+﻿{
+    "AdvancedWeatherForecast.Letter": "Olá @,^^Para melhor estudar as plantas e animais do vale, instalei recentemente um sistema avançado de previsão do tempo em meu laboratório.^Acredito que essa informação também possam ser útil para você, portanto, a partir de agora estarei atualizando o calendário da cidade com a previsão dos próximos dias.^Essa informação também será refletida nos seus calendários pessoais.^ - Demetrius",
+    "AdvancedWeatherForecast.Letter.Title": "Previsão do Tempo Avançada de Demetrius"
+}

--- a/AdvancedWeatherForecastMod/integrations/ApiLetter.cs
+++ b/AdvancedWeatherForecastMod/integrations/ApiLetter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace AdvancedWeatherForecastMod.integrations
+{
+    public class ApiLetter : ILetter
+    {
+        /// <summary>
+        /// this letter unique id
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// text to be show on the letter menu. You can use @ to put the players name and ^ for line breaks. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// this letter group id. Letter with the same group id are never delivered in the same day.
+        /// Letters registered first have priority, unless they have the suffix ".Random", in that case a random letter will be chosen.
+        /// </summary>
+        public string GroupId { get; set; }
+
+        /// <summary>
+        /// this letter title to be show in the collections menu. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// list of static items to be added in the letter. If null or empty, no item is added
+        /// There is a bug with the game when adding more than one object. It draws one over the other, and when clicked the one showing is the last one to be picked.
+        /// </summary>
+        public List<Item> Items { get; set; }
+
+        /// <summary>
+        /// name of the recipe to be learned with the letter
+        /// </summary>
+        public string Recipe { get; set; }
+
+        /// <summary>
+        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
+        /// </summary>
+        public int WhichBG { get; set; }
+
+        /// <summary>
+        /// custom texture to replace the game default. must follow the same proportions and image structure
+        /// </summary>
+        public Texture2D LetterTexture { get; set; }
+
+        /// <summary>
+        /// number of the text color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
+        /// </summary>
+        public int? TextColor { get; set; }
+
+        /// <summary>
+        /// custom texture to replace the game default close button. must follow the same proportions
+        /// </summary>
+        public Texture2D UpperRightCloseButtonTexture { get; set; }
+
+        /// <summary>
+        /// when conditions are met any recipe will be learned and the callback will be called. the letter won't show in the mailbox
+        /// </summary>
+        public bool AutoOpen { get; set; }
+
+        /// <summary>
+        /// translation helper of the content pack or mod
+        /// </summary>
+        public ITranslationHelper I18N { get; set; }
+    }
+}

--- a/AdvancedWeatherForecastMod/integrations/GenericModConfigMenuApi.cs
+++ b/AdvancedWeatherForecastMod/integrations/GenericModConfigMenuApi.cs
@@ -1,0 +1,57 @@
+﻿using StardewModdingAPI;
+using System;
+
+namespace AdvancedWeatherForecastMod.integrations
+{
+    public interface GenericModConfigMenuApi
+    {
+        /****
+         ** Must be called first
+         ****/
+        /// <summary>Register a mod whose config can be edited through the UI.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="reset">Reset the mod's config to its default values.</param>
+        /// <param name="save">Save the mod's current config to the <c>config.json</c> file.</param>
+        /// <param name="titleScreenOnly">Whether the options can only be edited from the title screen.</param>
+        /// <remarks>Each mod can only be registered once, unless it's deleted via <see cref="Unregister"/> before calling this again.</remarks>
+        void Register(IManifest mod, Action reset, Action save, bool titleScreenOnly = false);
+        /// <summary>Add a section title at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="text">The title text shown in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the title, or <c>null</c> to disable the tooltip.</param>
+        void AddSectionTitle(IManifest mod, Func<string> text, Func<string> tooltip = null);
+        /// <summary>Add a boolean option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddBoolOption(IManifest mod, Func<bool> getValue, Action<bool> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+        /// <summary>Add a float option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<float> getValue, Action<float> setValue, Func<string> name, Func<string> tooltip = null, float? min = null, float? max = null, float? interval = null, Func<float, string> formatValue = null, string fieldId = null);
+        /// <summary>Add an integer option at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="min">The minimum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="max">The maximum allowed value, or <c>null</c> to allow any.</param>
+        /// <param name="interval">The interval of values that can be selected.</param>
+        /// <param name="formatValue">Get the display text to show for a value, or <c>null</c> to show the number as-is.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddNumberOption(IManifest mod, Func<int> getValue, Action<int> setValue, Func<string> name, Func<string> tooltip = null, int? min = null, int? max = null, int? interval = null, Func<int, string> formatValue = null, string fieldId = null);
+
+    }
+}

--- a/AdvancedWeatherForecastMod/integrations/ILetter.cs
+++ b/AdvancedWeatherForecastMod/integrations/ILetter.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace AdvancedWeatherForecastMod.integrations
+{
+    public interface ILetter
+    {
+        /// <summary>
+        /// this letter unique id
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// text to be show on the letter menu. You can use @ to put the players name and ^ for line breaks. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        string Text { get; }
+
+        /// <summary>
+        /// this letter group id. Letter with the same group id are never delivered in the same day.
+        /// Letters registered first have priority, unless they have the suffix ".Random", in that case a random letter will be chosen.
+        /// </summary>
+        string GroupId { get; }
+        /// <summary>
+        /// this letter title to be show in the collections menu. Use a translation key if you provide a ITranslationHelper
+        /// </summary>
+        string Title { get; }
+
+        /// <summary>
+        /// list of static items to be added in the letter. If null or empty, no item is added
+        /// There is a bug with the game when adding more than one object. It draws one over the other, and when clicked the one showing is the last one to be picked.
+        /// </summary>
+        List<Item> Items { get; }
+
+        /// <summary>
+        /// name of the recipe to be learned with the letter
+        /// </summary>
+        string Recipe { get; }
+
+        /// <summary>
+        /// the id of the letter background. 0 = classic, 1 = notepad, 2 = pyramids
+        /// </summary>
+        int WhichBG { get; }
+
+        /// <summary>
+        /// custom texture to replace the game default. must follow the same proportions and image structure
+        /// </summary>
+        public Texture2D LetterTexture { get; }
+
+        /// <summary>
+        /// number of the text color. -1 = Dark Red, 0 = Black, 1 = Sky Blue, 2 = Red, 3 = Blue Violet, 4 = White, 5 = Orange Red, 6 = Lime Green, 7 = Cyan, 8 = Darkest Gray
+        /// </summary>
+        public int? TextColor { get; }
+
+        /// <summary>
+        /// custom texture to replace the game default close button. must follow the same proportions
+        /// </summary>
+        public Texture2D UpperRightCloseButtonTexture { get; }
+
+        /// <summary>
+        /// when conditions are met any recipe will be learned and the callback will be called. the letter won't show in the mailbox
+        /// </summary>
+        public bool AutoOpen { get; }
+
+        /// <summary>
+        /// translation helper of the content pack or mod
+        /// </summary>
+        public ITranslationHelper I18N { get; }
+    }
+}

--- a/AdvancedWeatherForecastMod/integrations/IMailFrameworkModApi.cs
+++ b/AdvancedWeatherForecastMod/integrations/IMailFrameworkModApi.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StardewModdingAPI;
+using StardewValley;
+
+namespace AdvancedWeatherForecastMod.integrations
+{
+    public interface IMailFrameworkModApi
+    {
+        public void RegisterLetter(ILetter iLetter, Func<ILetter, bool> condition, Action<ILetter> callback = null, Func<ILetter, List<Item>> dynamicItems = null);
+    }
+}

--- a/AdvancedWeatherForecastMod/manifest.json
+++ b/AdvancedWeatherForecastMod/manifest.json
@@ -1,0 +1,22 @@
+﻿{
+    "Name": "Advanced Weather Forecast Mod",
+    "Author": "Digus",
+    "Version": "1.0.0",
+    "Description": "Adds weather forecast beyond tomorrow.",
+    "UniqueID": "Digus.AdvancedWeatherForecastMod",
+    "EntryDll": "AdvancedWeatherForecastMod.dll",
+    "MinimumApiVersion": "4.0.0",
+    "Dependencies": [
+        {
+            "UniqueID": "DIGUS.MailFrameworkMod",
+            "MinimumVersion": "1.16.0",
+            "IsRequired": false
+        },
+        {
+            "UniqueID": "spacechase0.GenericModConfigMenu",
+            "MinimumVersion": "1.12.0",
+            "IsRequired": false
+        }
+    ],
+    "UpdateKeys": [ "Nexus:" ]
+}

--- a/AdvancedWeatherForecastMod/overrides/BillboardOverrides.cs
+++ b/AdvancedWeatherForecastMod/overrides/BillboardOverrides.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
+using StardewValley.Menus;
+using StardewValley;
+using static StardewValley.Menus.Billboard;
+
+namespace AdvancedWeatherForecastMod.overrides
+{
+    public class BillboardOverrides
+    {
+        public static void draw(Billboard __instance, SpriteBatch b)
+        {
+            bool dailyQuestBoard = AdvancedWeatherForecastModEntry.ModHelper.Reflection.GetField<bool>(__instance, "dailyQuestBoard").GetValue();
+            if (!dailyQuestBoard)
+            {
+                for (int i = 0; i < __instance.calendarDays.Count; i++)
+                {
+                    ClickableTextureComponent component = __instance.calendarDays[i];
+                    __instance.calendarDayData.TryGetValue(component.myID, out var day);
+                    bool wedding = day?.Type.HasFlag(BillboardEventType.Wedding) ?? false;
+                    if (!wedding)
+                    {
+
+                        int weatherIcon = 0;
+                        string weather;
+                        if (i == Game1.dayOfMonth % 28)
+                        {
+                            weather = Game1.currentLocation.GetWeather().WeatherForTomorrow;
+                        }
+                        else
+                        {
+                            var weatherData = WeatherDataRepository.GetWeatherData();
+                            var locationWeatherData = weatherData[Game1.currentLocation.locationContextId];
+                            if (i >= Game1.dayOfMonth)
+                            {
+                                if (!locationWeatherData.ContainsKey(Game1.Date.TotalDays + 1 + i - Game1.dayOfMonth)) continue;
+                                weather = locationWeatherData[Game1.Date.TotalDays + 1 + i - Game1.dayOfMonth];
+                            }
+                            else
+                            {
+                                if (!locationWeatherData.ContainsKey(Game1.Date.TotalDays + 29 + i - Game1.dayOfMonth)) continue;
+                                weather = locationWeatherData[Game1.Date.TotalDays + 29 + i - Game1.dayOfMonth];
+                            }
+                        }
+                        switch (weather)
+                        {
+                            case Game1.weather_green_rain:
+                                b.Draw(Game1.mouseCursors_1_6, new Vector2(component.bounds.Right - 48, component.bounds.Top + 4), new Rectangle(244, 294, 11, 7), Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, .75f);
+                                continue;
+                            case Game1.weather_festival:
+                                weatherIcon = 1;
+                                break;
+                            case Game1.weather_lightning:
+                                weatherIcon = 5;
+                                break;
+                            case Game1.weather_snow:
+                                weatherIcon = 7;
+                                break;
+                            case Game1.weather_rain:
+                                weatherIcon = 4;
+                                break;
+                            case Game1.weather_debris:
+                                if (i >= Game1.dayOfMonth)
+                                {
+                                    if (Game1.IsSpring) weatherIcon = 3;
+                                    if (Game1.IsFall) weatherIcon = 6;
+                                    if (Game1.IsWinter) weatherIcon = 7;
+                                }
+                                else
+                                {
+                                    if (Game1.IsWinter) weatherIcon = 3;
+                                    if (Game1.IsSummer) weatherIcon = 6;
+                                    if (Game1.IsFall) weatherIcon = 7;
+                                }
+
+                                break;
+                            default:
+                                weatherIcon = 2;
+                                break;
+                        };
+
+                        var sourceRectangle = new Rectangle(317 + 12 * weatherIcon, 422, 11, 7);
+                        b.Draw(Game1.mouseCursors, new Vector2(component.bounds.Right - 48, component.bounds.Top + 4), sourceRectangle, Color.White * 0.75f, 0f, Vector2.Zero, 4f, SpriteEffects.None, .5f);
+                    }
+
+                    Game1.mouseCursorTransparency = 1f;
+                    __instance.drawMouse(b);
+                    var hoverText = AdvancedWeatherForecastModEntry.ModHelper.Reflection.GetField<string>(__instance, "hoverText").GetValue();
+                    if (hoverText.Length > 0)
+                    {
+                        IClickableMenu.drawHoverText(b, hoverText, Game1.dialogueFont);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AdvancedWeatherForecastMod/overrides/LocationWeatherOverrides.cs
+++ b/AdvancedWeatherForecastMod/overrides/LocationWeatherOverrides.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+using Force.DeepCloner;
+using HarmonyLib;
+using Netcode;
+using StardewModdingAPI.Utilities;
+using StardewValley;
+using StardewValley.Extensions;
+using StardewValley.GameData.LocationContexts;
+using StardewValley.Network;
+using DataLoader = AdvancedWeatherForecastMod.common.DataLoader;
+
+namespace AdvancedWeatherForecastMod.overrides
+{
+    public class LocationWeatherOverrides
+    {
+        public static void UpdateDailyWeather_Prefix(LocationWeather __instance, string locationContextId)
+        {
+            if (!WeatherForecastController.IsFutureDay()) return;
+            WeatherForecastController.AddDateFutureDay();
+        }
+
+        public static void UpdateDailyWeather_Postfix(LocationWeather __instance, string locationContextId)
+        {
+            WeatherForecastController.ApplyWeatherModificationsForDateTomorrow(__instance);
+            if (!WeatherForecastController.IsFutureDay()) return;
+            WeatherForecastController.UpdateLocationWeatherData(__instance, locationContextId);
+            WeatherForecastController.SubtractDateFutureDay();
+        }
+
+        public static void UpdateWeatherForNewDay_Postfix()
+        {
+            if (DataLoader.ModConfig.DaysInAdvanceForecast <= 1) return;
+
+            WeatherForecastController.UpdateWeatherForTomorrow();
+            WeatherForecastController.CalculateWeatherForNewDay();
+            WeatherDataRepository.ClearPastWeatherData();
+        }
+    }
+}

--- a/StardewValleyMods.sln
+++ b/StardewValleyMods.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GemLampPostsMod", "GemLampP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdvancedCasksMod", "AdvancedCasksMod\AdvancedCasksMod.csproj", "{D23D5ED0-109B-4F84-8BAF-26278CC7F7E9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdvancedWeatherForecastMod", "AdvancedWeatherForecastMod\AdvancedWeatherForecastMod.csproj", "{832418C2-ACD5-4685-9156-6157E0526B34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
- Shows the weather forecast in the town's calendar and personal calendars.
- You can configure how many days in advance you can see the forecast, from 1 to 27.
- Adds console commands to clear or calculated the forecast. (some randoms are fixed per game, so a rainy day will never become sunny and vice versa)
- Adds API to check and edit future weather, so other mods can integrate with this one.
- Supports Generic Mod Config Menu.