### PR TITLE
[PFM] Make a branch in the performObjectDropInAction prefix not skip the vanilla function

### DIFF
--- a/ProducerFrameworkMod/ObjectOverrides.cs
+++ b/ProducerFrameworkMod/ObjectOverrides.cs
@@ -26,7 +26,7 @@ namespace ProducerFrameworkMod
         internal static bool PerformObjectDropInAction(Object __instance, Item dropInItem, bool probe, Farmer who, bool returnFalseIfItemConsumed, ref bool __result)
         {
             if (__instance.isTemporarilyInvisible || dropInItem is not Object input)
-                return false;
+                return true;
 
             bool failLocationCondition = false;
             bool failSeasonCondition = false;


### PR DESCRIPTION
This improves compatibility with other mods, namely Extra Machine Config's upcoming feature of allowing non-`Object` input in machines. Currently, if PFM is installed, this prefix detects that `dropInItem` is not an `Object` and skips the rest of the vanilla function, breaking EMC.