### PR TITLE
Fix Everlasting baits bug

### DIFF
--- a/EverlastingBaitsUnbreakableTacklesMod/DataLoader.cs
+++ b/EverlastingBaitsUnbreakableTacklesMod/DataLoader.cs
@@ -133,6 +133,7 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
                 )
             );
 
+            DataLoader.Helper.GameContent.InvalidateCache(CraftingrecipesAssetName);
             CreateConfigMenu(manifest);
         }
 
@@ -258,8 +259,10 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
                     , () => DataLoader.ModConfig.DisableBaits
                     , (bool val) =>
                     {
-                        if(DataLoader.ModConfig.DisableBaits != val) DataLoader.Helper.GameContent.InvalidateCache(CraftingrecipesAssetName);
+                        if (DataLoader.ModConfig.DisableBaits == val) 
+                            return;
                         DataLoader.ModConfig.DisableBaits = val;
+                        DataLoader.Helper.GameContent.InvalidateCache(CraftingrecipesAssetName);
                     }
                     , ()=> "Disable Baits"
                     , ()=> "Disable all features related to everlasting baits. You won't receive letters about it, the crafting recipes won't show, and existing everlasting baits will be consumed as normal."
@@ -271,8 +274,11 @@ namespace EverlastingBaitsAndUnbreakableTacklesMod
                     , () => DataLoader.ModConfig.DisableTackles
                     , (bool val) =>
                     {
-                        if (DataLoader.ModConfig.DisableTackles != val) DataLoader.Helper.GameContent.InvalidateCache(CraftingrecipesAssetName);
+                        if (DataLoader.ModConfig.DisableTackles == val) 
+                            return;
+                        
                         DataLoader.ModConfig.DisableTackles = val;
+                        DataLoader.Helper.GameContent.InvalidateCache(CraftingrecipesAssetName);
                     }
                     , () => "Disable Tackles"
                     , () => "Disable features related to everlasting baits. You won't receive letters starting quests, the crafting recipes won't show, and existing unbreakable tackles will wear out. Active quests will still show and be able to be ended if existing tackles."


### PR DESCRIPTION
There were two problems. 
The first is that the cache was invalidated BEFORE the changes to ModConfig were saved, causing unpredictable behaviour when enabling/disabling things in settings. 

The second is that the cache was never invalidated at the start, causing recipes to not get registered.