### PR TITLE
[Animal Husbandry] Handle null produces, and allows overriding feather/wool/feet drop

### DIFF
--- a/ButcherMod/animals/MeatController.cs
+++ b/ButcherMod/animals/MeatController.cs
@@ -165,7 +165,7 @@ namespace AnimalHusbandryMod.animals
 
                 for (; numberOfWools > 0; --numberOfWools)
                 {
-                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("woolIndex") ?? farmAnimal.GetProduceID(random, false) ?? "440", 1, ProduceQuality(random, farmAnimal));
+                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("woolIndex", null) ?? farmAnimal.GetProduceID(random, false) ?? "440", 1, ProduceQuality(random, farmAnimal));
                     itemsToReturn.Add(newItem);
                 }
             }
@@ -180,7 +180,7 @@ namespace AnimalHusbandryMod.animals
                     {
                         if (random.NextDouble() < ((double)farmAnimal.friendshipTowardFarmer.Value + (double)num1) / 5000.0 + Game1.player.DailyLuck + (double)Game1.player.LuckLevel * 0.01)
                         {
-                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("featherIndex") ?? farmAnimal.GetProduceID(random, true) ?? "444", 1, ProduceQuality(random, farmAnimal));
+                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("featherIndex", null) ?? farmAnimal.GetProduceID(random, true) ?? "444", 1, ProduceQuality(random, farmAnimal));
                             itemsToReturn.Add(newItem);
                         }
                     }
@@ -197,7 +197,7 @@ namespace AnimalHusbandryMod.animals
                     {
                         if (random.NextDouble() < ((double)farmAnimal.friendshipTowardFarmer.Value + (double)num1) / 5000.0 + Game1.player.DailyLuck + (double)Game1.player.LuckLevel * 0.01)
                         {
-                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("feetIndex") ?? farmAnimal.GetProduceID(random, true) ?? "446", 1, ProduceQuality(random, farmAnimal));
+                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("feetIndex", null) ?? farmAnimal.GetProduceID(random, true) ?? "446", 1, ProduceQuality(random, farmAnimal));
                             newItem.Quality = ProduceQuality(random, farmAnimal);
                             itemsToReturn.Add(newItem);
                         }

--- a/ButcherMod/animals/MeatController.cs
+++ b/ButcherMod/animals/MeatController.cs
@@ -165,7 +165,7 @@ namespace AnimalHusbandryMod.animals
 
                 for (; numberOfWools > 0; --numberOfWools)
                 {
-                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetProduceID(random, false), 1, ProduceQuality(random, farmAnimal));
+                    Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("woolIndex") ?? farmAnimal.GetProduceID(random, false) ?? "440", 1, ProduceQuality(random, farmAnimal));
                     itemsToReturn.Add(newItem);
                 }
             }
@@ -180,7 +180,7 @@ namespace AnimalHusbandryMod.animals
                     {
                         if (random.NextDouble() < ((double)farmAnimal.friendshipTowardFarmer.Value + (double)num1) / 5000.0 + Game1.player.DailyLuck + (double)Game1.player.LuckLevel * 0.01)
                         {
-                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetProduceID(random, true), 1, ProduceQuality(random, farmAnimal));
+                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("featherIndex") ?? farmAnimal.GetProduceID(random, true) ?? "444", 1, ProduceQuality(random, farmAnimal));
                             itemsToReturn.Add(newItem);
                         }
                     }
@@ -197,7 +197,7 @@ namespace AnimalHusbandryMod.animals
                     {
                         if (random.NextDouble() < ((double)farmAnimal.friendshipTowardFarmer.Value + (double)num1) / 5000.0 + Game1.player.DailyLuck + (double)Game1.player.LuckLevel * 0.01)
                         {
-                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetProduceID(random, true), 1, ProduceQuality(random, farmAnimal));
+                            Object newItem = ItemRegistry.Create<Object>(farmAnimal.GetAnimalData().CustomFields?.GetValueOrDefault("feetIndex") ?? farmAnimal.GetProduceID(random, true) ?? "446", 1, ProduceQuality(random, farmAnimal));
                             newItem.Quality = ProduceQuality(random, farmAnimal);
                             itemsToReturn.Add(newItem);
                         }


### PR DESCRIPTION
[Animal Multiproduce](https://www.nexusmods.com/stardewvalley/mods/27434) removes the deluxe produce from Ducks and Rabbits, causing `GetProduceID` to return `null` and causing butchered Ducks and Rabbits to throw an NRE. This fixes the issue by adding a fallback to vanilla items, and also adds the ability to manually specify custom feather/wool/feet drop for modded animals that can potentially be supported by Animal Multiproduce (though right now I believe you can't specify modded animals that drop feather/wool on butchering? Let me know if that that's in scope for a future PR, and/or more custom drops like leather/bones/etc.)